### PR TITLE
Replace literals

### DIFF
--- a/src/CanService.h
+++ b/src/CanService.h
@@ -7,6 +7,7 @@
 
 #include "Service.h"
 #include "UserInterface.h"
+#include <vlcbdefs.hpp>
 
 namespace VLCB
 {
@@ -19,7 +20,7 @@ class CanService : public Service
 public:
 
   virtual void setController(Controller *cntrl) override;
-  virtual byte getServiceID() override { return 3; }
+  virtual byte getServiceID() override { return SERVICE_ID_CAN; }
   virtual byte getServiceVersionID() override { return 1; }
 
   virtual void process(UserInterface::RequestedAction requestedAction) override;

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -233,12 +233,19 @@ void Configuration::readEvent(byte idx, byte tarr[])
   // DEBUG_SERIAL << F("> readEvent - idx = ") << idx << F(", nn = ") << (tarr[0] << 8) + tarr[1] << F(", en = ") << (tarr[2] << 8) + tarr[3] << endl;
 }
 
+// return the address an event variable is stored in the eeprom.
+// Note that the evnum is 1 based and needs to be converted to 0 based.
+unsigned int Configuration::getEVAddress(byte idx, byte evnum)
+{
+  return EE_EVENTS_START + (idx * EE_BYTES_PER_EVENT) + EE_HASH_BYTES + evnum - 1;
+}
+
 //
 /// return an event variable (EV) value given the event table index and EV number
 //
 byte Configuration::getEventEVval(byte idx, byte evnum)
 {
-  return storage->readEEPROM(EE_EVENTS_START + (idx * EE_BYTES_PER_EVENT) + 3 + evnum);
+  return storage->readEEPROM(getEVAddress(idx, evnum));
 }
 
 //
@@ -246,7 +253,7 @@ byte Configuration::getEventEVval(byte idx, byte evnum)
 //
 void Configuration::writeEventEV(byte idx, byte evnum, byte evval)
 {
-  storage->writeEEPROM(EE_EVENTS_START + (idx * EE_BYTES_PER_EVENT) + 3 + evnum, evval);
+  storage->writeEEPROM(getEVAddress(idx, evnum), evval);
 }
 
 //

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -46,7 +46,7 @@ Configuration::Configuration(Storage * theStorage)
 //
 void Configuration::begin()
 {
-  EE_BYTES_PER_EVENT = EE_NUM_EVS + 4;
+  EE_BYTES_PER_EVENT = EE_HASH_BYTES + EE_NUM_EVS;
 
   storage->begin();
   loadNVs();
@@ -91,7 +91,7 @@ void Configuration::setNodeNum(unsigned int nn)
 //
 byte Configuration::findExistingEvent(unsigned int nn, unsigned int en)
 {
-  byte tarray[4];
+  byte tarray[EE_HASH_BYTES];
   byte tmphash, i, j, matches;
   bool confirmed = false;
 
@@ -200,7 +200,7 @@ byte Configuration::findEventSpace()
 //
 /// create a hash from a 4-byte event entry array -- NN + EN
 //
-byte Configuration::makeHash(byte tarr[4])
+byte Configuration::makeHash(byte tarr[EE_HASH_BYTES])
 {
   // make a hash from a 4-byte NN + EN event
   unsigned int nn = (tarr[0] << 8) + tarr[1];
@@ -254,8 +254,8 @@ void Configuration::writeEventEV(byte idx, byte evnum, byte evval)
 //
 void Configuration::makeEvHashTable()
 {
-  byte evarray[4];
-  const byte unused_entry[4] = { 0xff, 0xff, 0xff, 0xff};
+  byte evarray[EE_HASH_BYTES];
+  const byte unused_entry[EE_HASH_BYTES] = { 0xff, 0xff, 0xff, 0xff};
 
   // DEBUG_SERIAL << F("> creating event hash table") << endl;
 
@@ -266,7 +266,7 @@ void Configuration::makeEvHashTable()
     readEvent(idx, evarray);
 
     // empty slots have all four bytes set to 0xff
-    if (memcmp(evarray, unused_entry, 4) == 0)
+    if (memcmp(evarray, unused_entry, EE_HASH_BYTES) == 0)
     {
       evhashtbl[idx] = 0;
     }
@@ -284,14 +284,14 @@ void Configuration::makeEvHashTable()
 //
 void Configuration::updateEvHashEntry(byte idx)
 {
-  byte evarray[4];
-  const byte unused_entry[4] = { 0xff, 0xff, 0xff, 0xff};
+  byte evarray[EE_HASH_BYTES];
+  const byte unused_entry[EE_HASH_BYTES] = { 0xff, 0xff, 0xff, 0xff};
 
   // read the first four bytes from EEPROM - NN + EN
   readEvent(idx, evarray);
 
   // empty slots have all four bytes set to 0xff
-  if (memcmp(evarray, unused_entry, 4) == 0)
+  if (memcmp(evarray, unused_entry, EE_HASH_BYTES) == 0)
   {
     evhashtbl[idx] = 0;
   }
@@ -405,12 +405,12 @@ void Configuration::writeNV(byte idx, byte val)
 /// write (or clear) an event to EEPROM
 /// just the first four bytes -- NN and EN
 //
-void Configuration::writeEvent(byte index, byte data[])
+void Configuration::writeEvent(byte index, byte data[EE_HASH_BYTES])
 {
   unsigned int eeaddress = EE_EVENTS_START + (index * EE_BYTES_PER_EVENT);
 
   // DEBUG_SERIAL << F("> writeEvent, index = ") << index << F(", addr = ") << eeaddress << endl;
-  storage->writeBytesEEPROM(eeaddress, data, 4);
+  storage->writeBytesEEPROM(eeaddress, data, EE_HASH_BYTES);
 }
 
 //

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -96,6 +96,8 @@ private:
 
   void loadNVs();
 
+  unsigned int getEVAddress(byte idx, byte evnum);
+
   byte *evhashtbl;
   bool hash_collision;
 };

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -187,7 +187,7 @@ void Controller::setLearnMode(byte reqMode)
       return;
     }
   }
-  sendGRSP(OPC_MODE, 4, GRSP_INVALID_SERVICE);
+  sendGRSP(OPC_MODE, SERVICE_ID_OLD_TEACH, GRSP_INVALID_SERVICE);
 } 
 
 //

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -172,7 +172,7 @@ void Controller::setLearnMode(byte reqMode)
 {
   for (Service * svc : services)
   {
-    if (svc->getServiceID() == 4)
+    if (svc->getServiceID() == SERVICE_ID_OLD_TEACH)
     {
       EventTeachingService * etSvc = (EventTeachingService *) svc;
       
@@ -406,7 +406,7 @@ void Controller::startCANenumeration()
   // Find it first.
   for (Service * svc : services)
   {
-    if (svc->getServiceID() == 3)
+    if (svc->getServiceID() == SERVICE_ID_CAN)
     {
       CanService * canSvc = (CanService *) svc;
       canSvc->startCANenumeration();

--- a/src/EventConsumerService.h
+++ b/src/EventConsumerService.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "Service.h"
+#include <vlcbdefs.hpp>
 
 namespace VLCB {
 
@@ -20,7 +21,7 @@ public:
 
   virtual byte getServiceID() override 
   {
-    return 6;
+    return SERVICE_ID_CONSUMER;
   }
   virtual byte getServiceVersionID() override 
   {

--- a/src/EventProducerService.h
+++ b/src/EventProducerService.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "Service.h"
+#include <vlcbdefs.hpp>
 
 namespace VLCB {
 
@@ -19,7 +20,7 @@ public:
 
   virtual byte getServiceID() override 
   {
-    return 5;
+    return SERVICE_ID_PRODUCER;
   }
   virtual byte getServiceVersionID() override 
   {

--- a/src/EventTeachingService.cpp
+++ b/src/EventTeachingService.cpp
@@ -21,16 +21,14 @@ void EventTeachingService::enableLearn()
 {
   bLearn = true;
   //DEBUG_SERIAL << F("> set learn mode ok") << endl;
-  // set bit 5 in parameter 8
-  bitSet(controller->_mparams[8], 5);
+  controller->_mparams[PAR_FLAGS] |= PF_LRN;
 }
 
 void EventTeachingService::inhibitLearn() 
 {
   bLearn = false;
   //DEBUG_SERIAL << F("> learn mode off") << endl;
-  // clear bit 5 in parameter 8
-  bitClear(controller->_mparams[8], 5);
+  controller->_mparams[PAR_FLAGS] &= ~PF_LRN;
 }
 
 Processed EventTeachingService::handleMessage(unsigned int opc, CANFrame *msg) 

--- a/src/EventTeachingService.h
+++ b/src/EventTeachingService.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "Service.h"
+#include <vlcbdefs.hpp>
 
 namespace VLCB 
 {
@@ -18,7 +19,7 @@ public:
   virtual void setController(Controller *cntrl) override;
   virtual Processed handleMessage(unsigned int opc, CANFrame *msg) override;
 
-  virtual byte getServiceID() override { return 4; }
+  virtual byte getServiceID() override { return SERVICE_ID_OLD_TEACH; }
   virtual byte getServiceVersionID() override { return 1; }
 
   void enableLearn();

--- a/src/LongMessageService.h
+++ b/src/LongMessageService.h
@@ -7,6 +7,7 @@
 
 #include "Service.h"
 #include "Transport.h"  // for DEFAULT_PRIORITY
+#include <vlcbdefs.hpp>
 
 namespace VLCB
 {
@@ -50,7 +51,7 @@ public:
   void setDelay(byte delay_in_millis);
   void setTimeout(unsigned int timeout_in_millis);
 
-  virtual byte getServiceID() override { return 17; }
+  virtual byte getServiceID() override { return SERVICE_ID_STREAMING; }
   virtual byte getServiceVersionID() override { return 1; }
 
 protected:

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -172,13 +172,13 @@ Processed MinimumNodeService::handleMessage(unsigned int opc, CANFrame *msg)
         // respond with PARAMS message
         msg->len = 8;
         msg->data[0] = OPC_PARAMS;    // opcode
-        msg->data[1] = controller->_mparams[1];     // manf code -- MERG
-        msg->data[2] = controller->_mparams[2];     // minor code ver
-        msg->data[3] = controller->_mparams[3];     // module ident
-        msg->data[4] = controller->_mparams[4];     // number of events
-        msg->data[5] = controller->_mparams[5];     // events vars per event
-        msg->data[6] = controller->_mparams[6];     // number of NVs
-        msg->data[7] = controller->_mparams[7];     // major code ver
+        msg->data[1] = controller->_mparams[PAR_MANU];     // manf code -- MERG
+        msg->data[2] = controller->_mparams[PAR_MINVER];     // minor code ver
+        msg->data[3] = controller->_mparams[PAR_MTYP];     // module ident
+        msg->data[4] = controller->_mparams[PAR_EVTNUM];     // number of events
+        msg->data[5] = controller->_mparams[PAR_EVNUM];     // events vars per event
+        msg->data[6] = controller->_mparams[PAR_NVNUM];     // number of NVs
+        msg->data[7] = controller->_mparams[PAR_MAJVER];     // major code ver
         
         controller->sendMessage(msg);
       }
@@ -204,12 +204,12 @@ Processed MinimumNodeService::handleMessage(unsigned int opc, CANFrame *msg)
           
           if (paran == 0)
           {
-            for (byte i = 0; i <= controller->_mparams[0]; i++)
+            for (byte i = 0; i <= controller->_mparams[PAR_NUM]; i++)
             {
               controller->sendMessageWithNN(OPC_PARAN, i, controller->_mparams[i]);
             }            
           }
-          else if (paran <= controller->_mparams[0])
+          else if (paran <= controller->_mparams[PAR_NUM])
           {
             controller->sendMessageWithNN(OPC_PARAN, paran, controller->_mparams[paran]);
           }

--- a/src/MinimumNodeService.h
+++ b/src/MinimumNodeService.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "Service.h"
+#include <vlcbdefs.hpp>
 
 namespace VLCB
 {
@@ -21,7 +22,7 @@ public:
   virtual void process(UserInterface::RequestedAction requestedAction) override; 
   virtual Processed handleMessage(unsigned int opc, CANFrame *msg) override;
 
-  virtual byte getServiceID() override { return 1; }
+  virtual byte getServiceID() override { return SERVICE_ID_MNS; }
   virtual byte getServiceVersionID() override { return 1; }
   
   virtual void begin() override;

--- a/src/NodeVariableService.h
+++ b/src/NodeVariableService.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "Service.h"
+#include <vlcbdefs.hpp>
 
 namespace VLCB
 {
@@ -18,7 +19,7 @@ class NodeVariableService : public Service
 public:
 
   virtual void setController(Controller *cntrl) override;
-  virtual byte getServiceID() override { return 2; }
+  virtual byte getServiceID() override { return SERVICE_ID_NV; }
   virtual byte getServiceVersionID() override { return 1; }
 
   virtual Processed handleMessage(unsigned int opc, CANFrame *msg) override;

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -12,40 +12,40 @@ unsigned char Parameters::params[21];
 
 void Parameters::initProcessorParams()
 {
-  params[9] = 50;
-  params[19] = CPUM_ATMEL;
+  params[PAR_CPUID] = 50;
+  params[PAR_CPUMAN] = CPUM_ATMEL;
 
   // set of pre-defined macros are taken from
   // https://github.com/backupbrain/ArduinoBoardManager/blob/master/ArduinoBoardManager.h
   // TODO: Provide values for all board types.
 #if defined(__AVR_ATmega328P__) // uno, fio
-  params[15] = '3';
-  params[16] = '2';
-  params[17] = '8';
-  params[18] = 'P';
+  params[PAR_CPUMID] = '3';
+  params[PAR_CPUMID+1] = '2';
+  params[PAR_CPUMID+2] = '8';
+  params[PAR_CPUMID+3] = 'P';
 //#elif defined(__AVR_ATSAMD21G18A__) // zero
 #elif defined(__AVR_ATSAM3X8E__) // Due
-  params[15] = '3';
-  params[16] = 'X';
-  params[17] = '8';
-  params[18] = 'E';
+  params[PAR_CPUMID] = '3';
+  params[PAR_CPUMID+1] = 'X';
+  params[PAR_CPUMID+2] = '8';
+  params[PAR_CPUMID+3] = 'E';
 //#elif defined(__AVR_Atmega32U4__) // Yun 16Mhz, Micro, Leonardo, Esplora
 //#elif defined(_AVR_AR9331__) // Yun 400Mhz
 #elif defined(__AVR_ATmega16U4__) // leonardo
-  params[15] = '1';
-  params[16] = '6';
-  params[17] = 'U';
-  params[18] = '4';
+  params[PAR_CPUMID] = '1';
+  params[PAR_CPUMID+1] = '6';
+  params[PAR_CPUMID+2] = 'U';
+  params[PAR_CPUMID+3] = '4';
 #elif defined(__AVR_ATmega1280__) // mega, Mega ADK
-  params[15] = '1';
-  params[16] = '2';
-  params[17] = '8';
-  params[18] = '0';
+  params[PAR_CPUMID] = '1';
+  params[PAR_CPUMID+1] = '2';
+  params[PAR_CPUMID+2] = '8';
+  params[PAR_CPUMID+3] = '0';
 #elif defined(__AVR_ATmega2560__) // mega, Mega ADK
-  params[15] = '2';
-  params[16] = '5';
-  params[17] = '6';
-  params[18] = '0';
+  params[PAR_CPUMID] = '2';
+  params[PAR_CPUMID+1] = '5';
+  params[PAR_CPUMID+2] = '6';
+  params[PAR_CPUMID+3] = '0';
 //#elif defined(_AVR_ATmega328__) // Nano >= v3.0 or Arduino Pro, pro328, ethernet
 //#elif defined(_AVR_ATmega168__) // Nano < v3.0 or uno, pro
 //#elif defined(_AVR_ATmega168V__) // LilyPad
@@ -53,10 +53,10 @@ void Parameters::initProcessorParams()
 //#elif defined(_AVR_ATTiny85__) // trinket
 //#elif  defined(__AVR_ARCv2EM__) || (__CURIE_FACTORY_DATA_H_) // Intel Curie/101
 #else
-  params[15] = '?';
-  params[16] = '?';
-  params[17] = '?';
-  params[18] = '?';
+  params[PAR_CPUMID] = '?';
+  params[PAR_CPUMID+1] = '?';
+  params[PAR_CPUMID+2] = '?';
+  params[PAR_CPUMID+3] = '?';
 #endif
 }
 

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -14,42 +14,42 @@ class Parameters
 public:
   explicit Parameters(Configuration const & config)
   {
-    params[0] = 20;                     //  0 num params = 20
-    params[1] = MANU_MERG;              //  1 manf = MERG, 165
-    params[4] = config.EE_MAX_EVENTS;   //  4 num events
-    params[5] = config.EE_NUM_EVS;      //  5 num evs per event
-    params[6] = config.EE_NUM_NVS;      //  6 num NVs
-    params[10] = PB_CAN;                // CAN implementation of Controller
-    params[11] = 0x00;
-    params[12] = 0x00;
-    params[13] = 0x00;
-    params[14] = 0x00;
+    params[PAR_NUM] = 20;                     //  0 num params = 20
+    params[PAR_MANU] = MANU_MERG;              //  1 manf = MERG, 165
+    params[PAR_EVTNUM] = config.EE_MAX_EVENTS;   //  4 num events
+    params[PAR_EVNUM] = config.EE_NUM_EVS;      //  5 num evs per event
+    params[PAR_NVNUM] = config.EE_NUM_NVS;      //  6 num NVs
+    params[PAR_BUSTYPE] = PB_CAN;                // CAN implementation of Controller
+    params[PAR_LOAD] = 0x00;
+    params[PAR_LOAD+1] = 0x00;
+    params[PAR_LOAD+2] = 0x00;
+    params[PAR_LOAD+3] = 0x00;
     initProcessorParams();
   }
 
   void setVersion(char major, char minor, char beta)
   {
-    params[7] = major;                //  7 code major version
-    params[2] = minor;                //  2 code minor version
-    params[20] = beta;                // 20 code beta version
+    params[PAR_MAJVER] = major;                //  7 code major version
+    params[PAR_MINVER] = minor;                //  2 code minor version
+    params[PAR_BETA] = beta;                // 20 code beta version
   }
 
   void setModuleId(byte id)
   {
-    params[3] = id;                   //  3 module id
+    params[PAR_MTYP] = id;                   //  3 module id
   }
 
   void setFlags(byte flags)
   {
-    params[8] = flags;                //  8 flags - FLiM, consumer/producer
+    params[PAR_FLAGS] = flags;                //  8 flags - FLiM, consumer/producer
   }
 
   // Optional: use this to override processor info that is set by default.
   void setProcessor(byte manufacturer, byte id, char const * name)
   {
-    params[9] = id;                  //  9 processor id
-    params[19] = manufacturer;       // 19 processor manufacturer
-    memcpy(params + 15, name, 4);   // 15-18 processor version
+    params[PAR_CPUID] = id;                  //  9 processor id
+    params[PAR_CPUMAN] = manufacturer;       // 19 processor manufacturer
+    memcpy(params + PAR_CPUMID, name, 4);   // 15-18 processor version
   }
 
   unsigned char * getParams()


### PR DESCRIPTION
This is to make use of the constants in VLCB-defs for self-documentation and for avoiding errors.