### PR TITLE
Add PF_SD flag and test for QNN.

### DIFF
--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -91,6 +91,9 @@ void Controller::setParams(unsigned char *mparams)
   {
     switch (svc->getServiceID())
     {
+      case SERVICE_ID_MNS:
+        flags |= PF_SD;
+        break;
       case SERVICE_ID_PRODUCER:
         flags |= PF_PRODUCER;
         break;
@@ -99,7 +102,7 @@ void Controller::setParams(unsigned char *mparams)
         break;
     }
   }
-  if (module_config->currentMode = MODE_NORMAL)
+  if (module_config->currentMode == MODE_NORMAL)
   {
     flags |= PF_NORMAL; 
   }

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -272,7 +272,7 @@ Processed MinimumNodeService::handleMessage(unsigned int opc, CANFrame *msg)
       if (module_config->nodeNum > 0)
       {
         // DEBUG_SERIAL << ("> responding with PNN message") << endl;
-        controller->sendMessageWithNN(OPC_PNN, controller->_mparams[1], controller->_mparams[3], controller->_mparams[8]);
+        controller->sendMessageWithNN(OPC_PNN, controller->_mparams[PAR_MANU], controller->_mparams[PAR_MTYP], controller->_mparams[PAR_FLAGS]);
       }
 
       return PROCESSED;

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -15,7 +15,7 @@ public:
   explicit Parameters(Configuration const & config)
   {
     params[PAR_NUM] = 20;                     //  0 num params = 20
-    params[PAR_MANU] = MANU_MERG;              //  1 manf = MERG, 165
+    params[PAR_MANU] = MANU_VLCB;              //  1 manf = MERG, 165
     params[PAR_EVTNUM] = config.EE_MAX_EVENTS;   //  4 num events
     params[PAR_EVNUM] = config.EE_NUM_EVS;      //  5 num evs per event
     params[PAR_NVNUM] = config.EE_NUM_NVS;      //  6 num NVs

--- a/src/vlcbdefs.hpp
+++ b/src/vlcbdefs.hpp
@@ -542,6 +542,7 @@ enum CbusParamFlags
   PF_BOOT = 8, // Module supports the FCU bootloader protocol
   PF_COE = 16, // Module can consume its own events
   PF_LRN = 32, // Module is in learn mode
+  PF_SD = 64, // Module supports Service Discovery
 };
 
 enum CbusBusTypes

--- a/test/testMinimumNodeService.cpp
+++ b/test/testMinimumNodeService.cpp
@@ -293,6 +293,26 @@ void testSetNodeNumberShort()
   assertEquals(CMDERR_INV_CMD, mockTransport->sent_messages[0].data[5]);
 }
 
+void testQueryNodeNumber()
+{
+  test();
+
+  VLCB::Controller controller = createController();
+
+  VLCB::CANFrame msg_rqsd = {0x11, false, false, 1, {OPC_QNN}};
+  mockTransport->setNextMessage(msg_rqsd);
+
+  controller.process();
+
+  assertEquals(1, mockTransport->sent_messages.size());
+  assertEquals(OPC_PNN, mockTransport->sent_messages[0].data[0]);
+  assertEquals(0x01, mockTransport->sent_messages[0].data[1]);
+  assertEquals(0x04, mockTransport->sent_messages[0].data[2]);
+  assertEquals(MANU_VLCB, mockTransport->sent_messages[0].data[3]);
+  assertEquals(MODULE_ID, mockTransport->sent_messages[0].data[4]);
+  assertEquals(PF_CONSUMER | PF_PRODUCER | PF_NORMAL | PF_SD, mockTransport->sent_messages[0].data[5]);
+}
+
 void testReadNodeParametersNormalMode()
 {
   test();
@@ -321,7 +341,7 @@ void testReadNodeParametersSetupMode()
 
   assertEquals(1, mockTransport->sent_messages.size());
   assertEquals(OPC_PARAMS, mockTransport->sent_messages[0].data[0]);
-  assertEquals(MANU_MERG, mockTransport->sent_messages[0].data[1]);
+  assertEquals(MANU_VLCB, mockTransport->sent_messages[0].data[1]);
   assertEquals(1, mockTransport->sent_messages[0].data[2]); // Minor version
   assertEquals(MODULE_ID, mockTransport->sent_messages[0].data[3]);
   assertEquals(1, mockTransport->sent_messages[0].data[7]); // Major version
@@ -348,12 +368,12 @@ void testReadNodeParameterCount()
   // Manufacturer
   assertEquals(OPC_PARAN, mockTransport->sent_messages[1].data[0]);
   assertEquals(1, mockTransport->sent_messages[1].data[3]);
-  assertEquals(MANU_MERG, mockTransport->sent_messages[1].data[4]);
+  assertEquals(MANU_VLCB, mockTransport->sent_messages[1].data[4]);
   
   // Flags
   assertEquals(OPC_PARAN, mockTransport->sent_messages[8].data[0]);
   assertEquals(8, mockTransport->sent_messages[8].data[3]);
-  assertEquals(PF_COMBI | PF_NORMAL, mockTransport->sent_messages[8].data[4]);
+  assertEquals(PF_COMBI | PF_NORMAL | PF_SD, mockTransport->sent_messages[8].data[4]);
 }
 
 void testReadNodeParameterModuleId()
@@ -579,6 +599,7 @@ void testMinimumNodeService()
   testSetNodeNumber();
   testSetNodeNumberNormal();
   testSetNodeNumberShort();
+  testQueryNodeNumber();
   testReadNodeParametersNormalMode();
   testReadNodeParametersSetupMode();
   testReadNodeParameterCount();


### PR DESCRIPTION
This updates vlcbdefs.hpp from the VLCB-defs repo with the PF_SD flag for service discovery support.
Also changed default manufacturer to MANU_VLCB.