### PR TITLE
Changes to opcode MODE operation (radical)

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -70,14 +70,14 @@ void Configuration::setModuleMode(ModuleMode f)
 void Configuration::setHeartbeat(bool beat)
 {
   heartbeat = beat;
-  byte mode = storage->readEEPROM(0);
+  byte mode = storage->readEEPROM(4);
   if (beat)
   {
-    bitSet(mode, 1);
+    bitSet(mode, 0);
   }
   else
   {
-    bitClear(mode,1);
+    bitClear(mode, 0);
   }
   storage->writeEEPROM(0, mode);
 }
@@ -88,11 +88,11 @@ void Configuration::setEventAck(bool ea)
   byte servicePersist = storage->readEEPROM(4);
   if (ea)
   {
-    bitSet(servicePersist, 0);
+    bitSet(servicePersist, 1);
   }
   else
   {
-    bitClear(servicePersist,0);
+    bitClear(servicePersist, 1);
   }
   storage->writeEEPROM(4, servicePersist);
 }
@@ -639,10 +639,10 @@ void Configuration::resetModule()
 void Configuration::loadNVs()
 {
   currentMode = (ModuleMode) (storage->readEEPROM(0) & 0x01); // Bit 0 persists Uninitialised / Normal mode
-  heartbeat = storage->readEEPROM(0) & 0x02; // Bit 1 persists no heartbeat or heartbeat
+  heartbeat = storage->readEEPROM(4) & 0x01; // Bit 1 persists no heartbeat or heartbeat
   CANID =    storage->readEEPROM(1);
   nodeNum =  (storage->readEEPROM(2) << 8) + storage->readEEPROM(3);
-  eventAck = storage->readEEPROM(4) & 0x01; // Bit 0 persists event Acknowledgement if set
+  eventAck = storage->readEEPROM(4) & 0x02; // Bit 0 persists event Acknowledgement if set
 }
 
 //

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -64,7 +64,6 @@ void Configuration::begin()
 void Configuration::setModuleMode(ModuleMode f)
 {
   currentMode = f;
-  byte oldMode = storage->readEEPROM(0);
   storage->writeEEPROM(0, f);
 }
 

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -82,6 +82,21 @@ void Configuration::setHeartbeat(bool beat)
   storage->writeEEPROM(0, mode);
 }
 
+void Configuration::setEventAck(bool ea)
+{
+  eventAck = ea;
+  byte servicePersist = storage->readEEPROM(4);
+  if (ea)
+  {
+    bitSet(servicePersist, 0);
+  }
+  else
+  {
+    bitClear(servicePersist,0);
+  }
+  storage->writeEEPROM(4, servicePersist);
+}
+
 //
 /// store the CANID
 //
@@ -624,9 +639,10 @@ void Configuration::resetModule()
 void Configuration::loadNVs()
 {
   currentMode = (ModuleMode) (storage->readEEPROM(0) & 0x01); // Bit 0 persists Uninitialised / Normal mode
-  heartbeat = storage->readEEPROM(0) & 0x02; // Bit 1 persists no heartbeat or heartbaet
+  heartbeat = storage->readEEPROM(0) & 0x02; // Bit 1 persists no heartbeat or heartbeat
   CANID =    storage->readEEPROM(1);
   nodeNum =  (storage->readEEPROM(2) << 8) + storage->readEEPROM(3);
+  eventAck = storage->readEEPROM(4) & 0x01; // Bit 0 persists event Acknowledgement if set
 }
 
 //

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -25,8 +25,6 @@ enum ModuleMode {
   MODE_UNINITIALISED = 0,
   MODE_NORMAL = 1,
   MODE_SETUP = 2,
-  MODE_LEARN = 3,
-  MODE_NHEARTB = 4
 };
 
 //
@@ -62,6 +60,7 @@ public:
 
   void setCANID(byte canid);
   void setModuleMode(ModuleMode m);
+  void setHeartbeat(bool beat);
   void setNodeNum(unsigned int nn);
 
   void setResetFlag();
@@ -76,6 +75,7 @@ public:
   byte EE_NUM_NVS;
   byte EE_PRODUCED_EVENTS;
 
+  bool heartbeat;
   byte CANID;
   ModuleMode currentMode;
   unsigned int nodeNum;

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -62,6 +62,7 @@ public:
   void setModuleMode(ModuleMode m);
   void setHeartbeat(bool beat);
   void setNodeNum(unsigned int nn);
+  void setEventAck(bool ea);
 
   void setResetFlag();
   void clearResetFlag();
@@ -76,6 +77,7 @@ public:
   byte EE_PRODUCED_EVENTS;
 
   bool heartbeat;
+  bool eventAck;
   byte CANID;
   ModuleMode currentMode;
   unsigned int nodeNum;

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -171,28 +171,6 @@ void Controller::indicateActivity()
   }
 }
 
-void Controller::setLearnMode(byte reqMode)
-{
-  for (Service * svc : services)
-  {
-    if (svc->getServiceID() == SERVICE_ID_OLD_TEACH)
-    {
-      EventTeachingService * etSvc = (EventTeachingService *) svc;
-      
-      if (reqMode == MODE_LEARN)
-      {
-        etSvc->enableLearn();
-      }
-      if (reqMode == MODE_NORMAL)
-      {
-        etSvc->inhibitLearn();
-      }
-      return;
-    }
-  }
-  sendGRSP(OPC_MODE, SERVICE_ID_OLD_TEACH, GRSP_INVALID_SERVICE);
-} 
-
 //
 /// main Controller message processing procedure
 //

--- a/src/EventTeachingService.cpp
+++ b/src/EventTeachingService.cpp
@@ -39,6 +39,24 @@ Processed EventTeachingService::handleMessage(unsigned int opc, CANFrame *msg)
 
   switch (opc) 
   {
+    case OPC_MODE:
+      // 76 - Set Operating Mode
+      //DEBUG_SERIAL << F("> MODE -- request op-code received for NN = ") << nn << endl;
+      byte requestedMode = msg->data[3];
+      switch (requestedMode)
+      {
+      case 0x08:
+        // Turn on Learn Mode
+        enableLearn();
+        return PROCESSED;
+        
+      case 0x09:
+        // Turn off Learn Mode
+        inhibitLearn();
+        return PROCESSED;
+      }
+      // if none of the above commands, let another service see message
+      break;       
 
     case OPC_NNLRN:
       // 53 - place into learn mode

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -22,6 +22,7 @@ void MinimumNodeService::begin()
 {
   //Initialise instantMode
   instantMode = module_config->currentMode;
+  noHeartbeat = !module_config->heartbeat;
   controller->indicateMode(instantMode);
   //DEBUG_SERIAL << F("> instant MODE initialise as: ") << instantMode << endl;
 }
@@ -383,104 +384,43 @@ Processed MinimumNodeService::handleMessage(unsigned int opc, CANFrame *msg)
           return PROCESSED;
         }        
         
-        byte newMode = msg->data[3];
-        //DEBUG_SERIAL << F("> MODE -- requested = ") << newMode << endl;
+        byte requestedMode = msg->data[3];
+        //DEBUG_SERIAL << F("> MODE -- requested = ") << requestedMode << endl;
         //DEBUG_SERIAL << F("> instant MODE  = ") << instantMode << endl;
-        switch (instantMode)
+        if (instantMode == MODE_NORMAL)
         {
-        case MODE_UNINITIALISED:
-          if (nn != 0)   // Not for this node
+          switch (requestedMode)
           {
-            return PROCESSED;
-          }
-          if (newMode != MODE_SETUP)
-          {
-            controller->sendGRSP(OPC_MODE, getServiceID(), CMDERR_INV_CMD);            
-          } 
-          else
-          {
-            initSetup();
-            controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_OK);
-          }          
-          return PROCESSED;
-          
-        case MODE_SETUP:
-          if (nn != 0)   // Not for this node
-          {
-            return PROCESSED;
-          } 
-          else
-          {
-            controller->sendGRSP(OPC_MODE, getServiceID(), CMDERR_INV_CMD);            
-          }
-          return PROCESSED;
-          
-        case MODE_NORMAL:
-          switch (newMode)
-          {
-          case MODE_SETUP:
+          case 0x00:
+          // Request Setup
             controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_OK);
             initSetupFromNormal();
-            break;
-          
-          case MODE_LEARN:
-            //DEBUG_SERIAL << F("> MODE -- Learn") << endl;
-            controller->setLearnMode(newMode);
-            instantMode = newMode;
-            controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_OK);
-            break;
-          
-          case MODE_NHEARTB:          
-            //DEBUG_SERIAL << F("> MODE -- request no Heartbeats") << endl;
+            return PROCESSED;
+            
+          case 0x0C:
+          // Turn on Heartbeat
+            noHeartbeat = false;
+            module_config->setHeartbeat(!noHeartbeat);
+            return PROCESSED;
+            
+          case 0x0D:
+          // Turn off Heartbeat
             noHeartbeat = true;
-            instantMode = newMode;
-            break;
+            module_config->setHeartbeat(!noHeartbeat);
+            return PROCESSED;
           }
-          return PROCESSED;
-          
-        case MODE_LEARN:
-          if (newMode == MODE_SETUP)
-          {
-            controller->sendGRSP(OPC_MODE, getServiceID(), CMDERR_INV_CMD); 
-          }
-          if (newMode == MODE_NORMAL)
-          {
-            controller->setLearnMode(newMode);
-            if (noHeartbeat == true)
-            {
-              instantMode = MODE_NHEARTB;
-            }
-            else
-            {
-              instantMode = newMode;
-            }
-          } 
-          return PROCESSED;
-          
-        case MODE_NHEARTB:
-          if (newMode == MODE_SETUP)
-          {
-            noHeartbeat = false;
-            controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_OK);
-            initSetupFromNormal();
-          }
-          if (newMode == MODE_NORMAL)
-          {
-            noHeartbeat = false;
-            instantMode = newMode;
-            controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_OK);
-          }
-          if (newMode == MODE_LEARN)
-          {
-            controller->setLearnMode(newMode);
-            instantMode = newMode;
-            controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_OK);
-          } 
+          // if in MODE_NORMAL but none of the above commands, let another service see message
+          break;  
+        }
+        else
+        {
           return PROCESSED;
         }
       }
-      
+      else
+      {
       return PROCESSED;
+      }
       
     case OPC_NNRSM:
       //4F - reset to manufacturer's defaults 

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -376,52 +376,52 @@ Processed MinimumNodeService::handleMessage(unsigned int opc, CANFrame *msg)
     case OPC_MODE:
       // 76 - Set Operating Mode
        //DEBUG_SERIAL << F("> MODE -- request op-code received for NN = ") << nn << endl;
-      if (nn == module_config->nodeNum)
-      {        
-        if (msg->len < 4)
-        {          
-          controller->sendGRSP(OPC_MODE, getServiceID(), CMDERR_INV_CMD);
-          return PROCESSED;
-        }        
-        
-        byte requestedMode = msg->data[3];
-        //DEBUG_SERIAL << F("> MODE -- requested = ") << requestedMode << endl;
-        //DEBUG_SERIAL << F("> instant MODE  = ") << instantMode << endl;
-        if (instantMode == MODE_NORMAL)
-        {
-          switch (requestedMode)
-          {
-          case 0x00:
-          // Request Setup
-            controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_OK);
-            initSetupFromNormal();
-            return PROCESSED;
-            
-          case 0x0C:
-          // Turn on Heartbeat
-            noHeartbeat = false;
-            module_config->setHeartbeat(!noHeartbeat);
-            return PROCESSED;
-            
-          case 0x0D:
-          // Turn off Heartbeat
-            noHeartbeat = true;
-            module_config->setHeartbeat(!noHeartbeat);
-            return PROCESSED;
-          }
-          // if in MODE_NORMAL but none of the above commands, let another service see message
-          break;  
-        }
-        else
-        {
-          return PROCESSED;
-        }
-      }
-      else
+      if (nn != module_config->nodeNum)
       {
-      return PROCESSED;
+        return PROCESSED;
+      }
+      if (msg->len < 4)
+      {          
+        controller->sendGRSP(OPC_MODE, getServiceID(), CMDERR_INV_CMD);
+        return PROCESSED;
+      }        
+      
+      byte requestedMode = msg->data[3];
+      //DEBUG_SERIAL << F("> MODE -- requested = ") << requestedMode << endl;
+      //DEBUG_SERIAL << F("> instant MODE  = ") << instantMode << endl;
+      if (instantMode != MODE_NORMAL)
+      {
+        return PROCESSED;
       }
       
+      switch (requestedMode)
+      {
+      case 0xFF:
+      // Request Uninitialised
+        controller->sendGRSP(OPC_MODE, getServiceID(), CMDERR_INV_CMD);
+        return PROCESSED;
+        
+      case 0x00:
+      // Request Setup
+        controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_OK);
+        initSetupFromNormal();
+        return PROCESSED;
+        
+      case 0x0C:
+      // Turn on Heartbeat
+        noHeartbeat = false;
+        module_config->setHeartbeat(!noHeartbeat);
+        return PROCESSED;
+        
+      case 0x0D:
+      // Turn off Heartbeat
+        noHeartbeat = true;
+        module_config->setHeartbeat(!noHeartbeat);
+        return PROCESSED;
+      }      
+      // if in MODE_NORMAL but none of the above commands, let another service see message
+      return NOT_PROCESSED;  
+            
     case OPC_NNRSM:
       //4F - reset to manufacturer's defaults 
       if (nn == module_config->nodeNum)

--- a/src/MinimumNodeService.h
+++ b/src/MinimumNodeService.h
@@ -51,7 +51,7 @@ private:
   
   unsigned long lastHeartbeat = 0;
   byte heartbeatSequence = 0;
-  bool noHeartbeat = false;
+  bool noHeartbeat;
   unsigned int heartRate = 5000;
 };
 

--- a/src/MinimumNodeService.h
+++ b/src/MinimumNodeService.h
@@ -51,7 +51,7 @@ private:
   
   unsigned long lastHeartbeat = 0;
   byte heartbeatSequence = 0;
-  bool noHeartbeat;
+  bool noHeartbeat = false;
   unsigned int heartRate = 5000;
 };
 


### PR DESCRIPTION
Radical changes to opcode MODE implementation in line with Ian Hogg's proposal modified by Martin Da Costa's amendments.  If MNS has validated the NN, is in NORMAL mode, but does not respond to the particular command, the message is passed to the next service and so on down the line.  Any service that responds to a command will respond with PROCESSED.
enum ModuleMode{} has been reduced to 3 entries as they are the only ones required. (configuration.h)
In configuration.cpp, EEPROM(0) uses bit 0 to define Uninitialised or Normal and bit 1 to define heartbeat.  heartbeat will always revert to default when setModuleMode sets Normal.  This will happen following a node number change even if mode only goes Normal - Setup - Normal.  heartbeat currently defaults to noHeartbeat, which is at variance with the spec as written but can be easily changed.