### PR TITLE
Fix memory problem in initializer_list

### DIFF
--- a/src/ArrayHolder.h
+++ b/src/ArrayHolder.h
@@ -16,6 +16,7 @@ class ArrayHolder
 {
 public:
   ArrayHolder(const std::initializer_list<E> & il);
+  ~ArrayHolder();
 
   // Number of elements.
   constexpr size_t
@@ -41,6 +42,14 @@ ArrayHolder<E>::ArrayHolder(const std::initializer_list<E> &il)
   : array(copyArray(il.begin(), il.size()))
   , len(il.size())
 { }
+
+template<typename E>
+ArrayHolder<E>::~ArrayHolder()
+{
+  delete array;
+  array = 0;
+  len = 0;
+}
 
 template<typename E>
 E* ArrayHolder<E>::copyArray(const E * a, size_t len)

--- a/src/ArrayHolder.h
+++ b/src/ArrayHolder.h
@@ -1,0 +1,56 @@
+//  Copyright (C) Sven Rosvall (sven@rosvall.ie)
+//  This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+//  Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+//  The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0
+//
+
+#pragma once
+
+#include "initializer_list.h"
+
+namespace VLCB
+{
+
+template<typename E>
+class ArrayHolder
+{
+public:
+  ArrayHolder(const std::initializer_list<E> & il);
+
+  // Number of elements.
+  constexpr size_t
+  size() const noexcept { return len; }
+
+  // First element.
+  constexpr const E*
+  begin() const noexcept { return array; }
+
+  // One past the last element.
+  constexpr const E*
+  end() const noexcept { return begin() + size(); }
+
+private:
+  static E* copyArray(const E * a, size_t len);
+
+  const E* array;
+  size_t len;
+};
+
+template<typename E>
+ArrayHolder<E>::ArrayHolder(const std::initializer_list<E> &il)
+  : array(copyArray(il.begin(), il.size()))
+  , len(il.size())
+{ }
+
+template<typename E>
+E* ArrayHolder<E>::copyArray(const E * a, size_t len)
+{
+  E * array = new E[len];
+  for (int i = 0 ; i < len ; ++i)
+  {
+    array[i] = a[i];
+  }
+  return array;
+}
+
+}

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -16,6 +16,7 @@
 #include "UserInterface.h"
 #include "Service.h"
 #include "initializer_list.h"
+#include "ArrayHolder.h"
 
 namespace VLCB
 {
@@ -74,7 +75,7 @@ public:
 private:                                          // protected members become private in derived classes
   UserInterface *_ui;
   Configuration *module_config;
-  std::initializer_list<Service *> services;
+  ArrayHolder<Service *> services;
   Transport * transport;
 
   unsigned char *_mparams;

--- a/src/initializer_list.h
+++ b/src/initializer_list.h
@@ -21,7 +21,7 @@ namespace std
       // This copy ctor is only used in test code for creating a controller.
       initializer_list(const initializer_list & rhs)
         : len(rhs.len)
-        , array(copyArray(rhs.array, rhs.len))
+        , array(rhs.array)
       {
       }
 
@@ -42,16 +42,6 @@ namespace std
       constexpr initializer_list(const E* a, size_t l)
         : array(a), len(l) { }
         
-      static E* copyArray(const E * a, size_t len)
-      {
-        E * array = new E[len];
-        for (int i = 0 ; i < len ; ++i)
-        {
-          array[i] = a[i];
-        }
-        return array;
-      }
-
       const E* array;
       size_t len;
     };

--- a/src/initializer_list.h
+++ b/src/initializer_list.h
@@ -17,13 +17,6 @@ namespace std
     public:
 
       constexpr initializer_list() noexcept : array(0), len(0) { }
-      
-      // This copy ctor is only used in test code for creating a controller.
-      initializer_list(const initializer_list & rhs)
-        : len(rhs.len)
-        , array(rhs.array)
-      {
-      }
 
       // Number of elements.
       constexpr size_t


### PR DESCRIPTION
The memory in initializer_list is a temporary array created by the compiler. This memory needs to stored in a managed container.