### PR TITLE
Fix startup after factory reset.

### DIFF
--- a/examples/VLCB_1in1out/VLCB_1in1out.ino
+++ b/examples/VLCB_1in1out/VLCB_1in1out.ino
@@ -82,7 +82,16 @@ void setupVLCB()
   // initialise and load configuration
   controller.begin();
 
-  Serial << F("> mode = ") << ((modconfig.currentMode) ? "Normal" : "Uninitialised") << F(", CANID = ") << modconfig.CANID;
+  const char * modeString;
+  switch (modconfig.currentMode)
+  {
+    case MODE_NORMAL: modeString = "Normal"; break;
+    case MODE_SETUP: modeString = "Setup"; break;
+    case MODE_UNINITIALISED: modeString = "Uninitialised"; break;
+    default: modeString = "Unknown"; break;
+  }
+  Serial << F("> mode = (") << _HEX(modconfig.currentMode) << ") " << modeString;
+  Serial << F(", CANID = ") << modconfig.CANID;
   Serial << F(", NN = ") << modconfig.nodeNum << endl;
 
   // show code version and copyright notice

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -53,9 +53,10 @@ void Configuration::begin()
   
   if ((storage->read(LOCATION_MODE) == 0xFF) && (nodeNum == 0xFFFF))   // EEPROM is in factory virgin state
   {
-   resetModule();
-   clearResetFlag();
-   loadNVs();   
+    // DEBUG_SERIAL << "Configuration::begin() - EEPROM is factory reset. Resetting module." << endl;
+    resetModule();
+    clearResetFlag();
+    loadNVs();   
   }
   
   makeEvHashTable();  
@@ -625,12 +626,13 @@ void Configuration::resetModule()
 //
 void Configuration::loadNVs()
 {
-  currentMode = (VlcbModeParams) (storage->read(LOCATION_MODE) & 0x01); // Bit 0 persists Uninitialised / Normal mode
+  currentMode = (VlcbModeParams) (storage->read(LOCATION_MODE) ); // Bit 0 persists Uninitialised / Normal mode
   CANID = storage->read(LOCATION_CANID);
   nodeNum = (storage->read(LOCATION_NODE_NUMBER_HIGH) << 8) + storage->read(LOCATION_NODE_NUMBER_LOW);
   byte flags = storage->read(LOCATION_FLAGS);
   heartbeat = flags & (1 << HEARTBEAT_BIT);
   eventAck = flags & (1 << EVENT_ACK_BIT);
+  // DEBUG_SERIAL << "Configuration::loadNVs() mode=" << currentMode << ", CANID=" << CANID << ", nodeNum=" << nodeNum << ", flags=" << _HEX(flags) << endl;
 }
 
 //


### PR DESCRIPTION
After a factory reset (where EEPROM is set to FF) the module comes up in Normal mode. This changes the setup so that the module actualy starts in Uninitialized mode.