### PR TITLE
Refactor CAN enumeration logic

### DIFF
--- a/Arduino/ACAN2515.h
+++ b/Arduino/ACAN2515.h
@@ -26,9 +26,9 @@ struct ACAN2515Settings
 struct CANMessage
 {
   uint32_t id;
-  uint8_t len;
-  bool rtr;
   bool ext;
+  bool rtr;
+  uint8_t len;
   uint8_t data[8];
 };
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ add_library(core_library OBJECT
         src/Parameters.cpp
         src/Parameters.h
         src/Transport.h
+        src/CanTransport.cpp
+        src/CanTransport.h
         src/Storage.h
         src/UserInterface.h
         src/Service.h
@@ -87,5 +89,8 @@ add_executable(testAll
         test/MockUserInterface.cpp
         test/MockTransport.cpp
         test/MockStorage.cpp
+        test/MockTransport.h
+        test/MockCanTransport.cpp
+        test/MockCanTransport.h
         test/VlcbCommon.cpp
 )

--- a/TODO.md
+++ b/TODO.md
@@ -43,6 +43,10 @@ These fields can be populated within the transport class.
 Once this refactoring is done, CANFrame can be renamed to something more generic
 such as ```VlcbMessage```.
 
+The CAN specifics are exposed to some services. 
+* CanService checks if RTR is set and checks for CANID collisions.
+* LongMessageService relies on CANID for stringing messages together.
+
 ### Event lookup
 Duncan use a hash value for quick search in the event table and reduce the 
 number of EEPROM reads.

--- a/TODO.md
+++ b/TODO.md
@@ -34,19 +34,6 @@ The user code should be able to reserve a chunk of bytes in this space.
 
 ## Potential bugs and opportunities for improvement
 
-### Make CANFrame Generic
-The struct CANFrame is currently a copy of CANMessage from ACAN2515. 
-CANFrame doesn't need the CAN specific fields such as ```id```, ```ext``` and ```rtr```.
-These fields can be populated within the transport class.
-```id``` is already populated within the CAN2515 class with the value from module configuration.
-
-Once this refactoring is done, CANFrame can be renamed to something more generic
-such as ```VlcbMessage```.
-
-The CAN specifics are exposed to some services. 
-* CanService checks if RTR is set and checks for CANID collisions.
-* LongMessageService relies on CANID for stringing messages together.
-
 ### Event lookup
 Duncan use a hash value for quick search in the event table and reduce the 
 number of EEPROM reads.

--- a/examples/VLCB4IN4OUT/VLCB4IN4OUT.ino
+++ b/examples/VLCB4IN4OUT/VLCB4IN4OUT.ino
@@ -94,7 +94,7 @@ VLCB::LEDUserInterface userInterface(LED_GRN, LED_YLW, SWITCH0);
 VLCB::Configuration modconfig;               // configuration object
 VLCB::CAN2515 can2515;                  // CAN transport object
 VLCB::MinimumNodeService mnService;
-VLCB::CanService canService;
+VLCB::CanService canService(&can2515);
 VLCB::NodeVariableService nvService;
 VLCB::EventConsumerService ecService;
 VLCB::EventTeachingService etService;

--- a/examples/VLCB_1in1out/VLCB_1in1out.ino
+++ b/examples/VLCB_1in1out/VLCB_1in1out.ino
@@ -20,7 +20,7 @@
 #include <LED.h>                // VLCB LEDs
 #include <Configuration.h>             // module configuration
 #include <Parameters.h>             // VLCB parameters
-#include <vlcbdefs.hpp>               // MERG CBUS constants
+#include <vlcbdefs.hpp>               // VLCB constants
 #include <LEDUserInterface.h>
 #include "MinimumNodeService.h"
 #include "CanService.h"
@@ -44,7 +44,7 @@ VLCB::LEDUserInterface userInterface(LED_GRN, LED_YLW, SWITCH0);
 VLCB::Configuration modconfig;               // configuration object
 VLCB::CAN2515 can2515;                  // CAN transport object
 VLCB::MinimumNodeService mnService;
-VLCB::CanService canService;
+VLCB::CanService canService(&can2515);
 VLCB::NodeVariableService nvService;
 VLCB::EventConsumerService ecService;
 VLCB::EventTeachingService etService;

--- a/examples/VLCB_empty/VLCB_empty.ino
+++ b/examples/VLCB_empty/VLCB_empty.ino
@@ -18,7 +18,7 @@
 #include <CAN2515.h>               // CAN controller
 #include <Configuration.h>             // module configuration
 #include <Parameters.h>             // VLCB parameters
-#include <vlcbdefs.hpp>               // MERG CBUS constants
+#include <vlcbdefs.hpp>               // VLCB constants
 #include <LEDUserInterface.h>
 #include "MinimumNodeService.h"
 #include "CanService.h"
@@ -42,7 +42,7 @@ VLCB::LEDUserInterface userInterface(LED_GRN, LED_YLW, SWITCH0);
 VLCB::Configuration modconfig;               // configuration object
 VLCB::CAN2515 can2515;                  // CAN transport object
 VLCB::MinimumNodeService mnService;
-VLCB::CanService canService;
+VLCB::CanService canService(&can2515);
 VLCB::NodeVariableService nvService;
 VLCB::EventConsumerService ecService;
 VLCB::EventTeachingService etService;

--- a/examples/VLCB_empty/VLCB_empty.ino
+++ b/examples/VLCB_empty/VLCB_empty.ino
@@ -193,7 +193,7 @@ void framehandler(VLCB::CANFrame *msg)
 {
   // as an example, format and display the received frame
 
-  Serial << "[ " << (msg->id & 0x7f) << "] [" << msg->len << "] [";
+  Serial << "[" << msg->len << "] [";
 
   for (byte d = 0; d < msg->len; d++)
   {

--- a/examples/VLCB_long_message_example/VLCB_long_message_example.ino
+++ b/examples/VLCB_long_message_example/VLCB_long_message_example.ino
@@ -18,7 +18,7 @@
 #include <CAN2515.h>               // CAN controller
 #include <Configuration.h>             // module configuration
 #include <Parameters.h>             // VLCB parameters
-#include <vlcbdefs.hpp>               // MERG CBUS constants
+#include <vlcbdefs.hpp>               // VLCB constants
 #include <LEDUserInterface.h>
 #include "MinimumNodeService.h"
 #include <LongMessageService.h>
@@ -43,7 +43,7 @@ VLCB::LEDUserInterface userInterface(LED_GRN, LED_YLW, SWITCH0);
 VLCB::Configuration modconfig;               // configuration object
 VLCB::CAN2515 can2515;                  // CAN transport object
 VLCB::MinimumNodeService mnService;
-VLCB::CanService canService;
+VLCB::CanService canService(&can2515);
 VLCB::NodeVariableService nvService;
 VLCB::LongMessageService lmsg;        // Controller RFC0005 long message object
 VLCB::EventConsumerService ecService;

--- a/examples/VLCB_long_message_example/VLCB_long_message_example.ino
+++ b/examples/VLCB_long_message_example/VLCB_long_message_example.ino
@@ -208,7 +208,7 @@ void framehandler(VLCB::CANFrame *msg)
 {
   // as an example, format and display the received frame
 
-  Serial << "[ " << (msg->id & 0x7f) << "] [" << msg->len << "] [";
+  Serial << "[" << msg->len << "] [";
 
   for (byte d = 0; d < msg->len; d++)
   {

--- a/src/CAN2515.cpp
+++ b/src/CAN2515.cpp
@@ -132,28 +132,14 @@ CANMessage CAN2515::getNextCanMessage()
 //
 /// send a VLCB message
 //
-bool CAN2515::sendMessage(CANFrame *msg, bool rtr, bool ext, byte priority)
+bool CAN2515::sendCanMessage(CANMessage *msg)
 {
-  // caller must populate the message data
-  // this method will create the correct frame header (CAN ID and priority bits)
-  // rtr and ext default to false unless arguments are supplied - see method definition in .h
-  // priority defaults to 1011 low/medium
-
-  // TODO: Move this message translation to CanTransport
-  CANMessage message;       // ACAN2515 frame class
-  makeHeader(msg, priority);                      // default priority unless user overrides
-  message.id = msg->id;
-  message.len = msg->len;
-  message.rtr = rtr;
-  message.ext = ext;
-  memcpy(message.data, msg->data, msg->len);
-
-//  DEBUG_SERIAL << F("CAN2515 sendMessage id=") << (msg->id & 0x7F) << " len=" << msg->len << " rtr=" << rtr;
+//  DEBUG_SERIAL << F("CAN2515 sendCanMessage id=") << (msg->id & 0x7F) << " len=" << msg->len << " rtr=" << rtr;
 //  if (msg->len > 0)
 //    DEBUG_SERIAL << " op=" << _HEX(msg->data[0]);
 //  DEBUG_SERIAL << endl;
 
-  bool ret = canp->tryToSend(message);
+  bool ret = canp->tryToSend(*msg);
   _numMsgsSent += ret;
 
   // Simple workaround for sending many messages. Let the underlying hardware some time to send this message before next.
@@ -227,25 +213,6 @@ void CAN2515::setNumBuffers(byte num_rx_buffers, byte num_tx_buffers)
 void CAN2515::setOscFreq(unsigned long freq)
 {
   _osc_freq = freq;
-}
-
-//
-/// actual implementation of the makeHeader method
-/// so it can be called directly or as a Controller class method
-/// the 11 bit ID of a standard CAN frame is comprised of: (4 bits of CAN priority) + (7 bits of CAN ID)
-/// priority = 1011 (0xB hex, 11 dec) as default argument, which translates to medium/low
-//
-inline void makeHeader_impl(CANFrame *msg, byte id, byte priority)
-{
-  msg->id = (priority << 7) + (id & 0x7f);
-}
-
-//
-/// utility method to populate a VLCB message header
-//
-void CAN2515::makeHeader(CANFrame *msg, byte priority)
-{
-  makeHeader_impl(msg, controller->getModuleCANID(), priority);
 }
 
 }

--- a/src/CAN2515.cpp
+++ b/src/CAN2515.cpp
@@ -112,26 +112,21 @@ bool CAN2515::available()
 /// get next unprocessed message from the buffer
 /// must call available first to ensure there is something to get
 //
-CANFrame CAN2515::getNextMessage()
+CANMessage CAN2515::getNextCanMessage()
 {
   // DEBUG_SERIAL << F("CAN2515 trying to get next message.") << endl;
   CANMessage message;       // ACAN2515 frame class
 
   canp->receive(message);
 
-  CANFrame msg;
-  msg.id = message.id;
-  msg.len = message.len;
-  msg.rtr = message.rtr;
-  msg.ext = message.ext;
-  memcpy(msg.data, message.data, message.len);
-//  DEBUG_SERIAL << F("CAN2515 getNextMessage id=") << (msg.id & 0x7F) << " len=" << msg.len << " rtr=" << msg.rtr;
+//  DEBUG_SERIAL << F("CAN2515 getNextCanMessage id=") << (msg.id & 0x7F) << " len=" << msg.len << " rtr=" << msg.rtr;
 //  if (msg.len > 0)
 //    DEBUG_SERIAL << " op=" << _HEX(msg.data[0]);
 //  DEBUG_SERIAL << endl;
 
   ++_numMsgsRcvd;
-  return msg;
+  
+  return message;
 }
 
 //
@@ -144,6 +139,7 @@ bool CAN2515::sendMessage(CANFrame *msg, bool rtr, bool ext, byte priority)
   // rtr and ext default to false unless arguments are supplied - see method definition in .h
   // priority defaults to 1011 low/medium
 
+  // TODO: Move this message translation to CanTransport
   CANMessage message;       // ACAN2515 frame class
   makeHeader(msg, priority);                      // default priority unless user overrides
   message.id = msg->id;

--- a/src/CAN2515.h
+++ b/src/CAN2515.h
@@ -42,8 +42,8 @@ public:
   bool begin(bool poll = false, SPIClass spi = SPI);
 #endif
   bool available() override;
-  CANMessage getNextCanMessage();
-  bool sendMessage(CANFrame *msg, bool rtr = false, bool ext = false, byte priority = DEFAULT_PRIORITY) override;    // note default arguments
+  CANMessage getNextCanMessage() override;
+  bool sendCanMessage(CANMessage *msg) override;
   void reset() override;
 
   // these methods are specific to this implementation
@@ -57,8 +57,6 @@ public:
 #else
   void setPins(byte cs_pin, byte int_pin);
 #endif
-
-  void makeHeader(CANFrame *msg, byte priority = DEFAULT_PRIORITY);
 
   ACAN2515 *canp;   // pointer to CAN object so user code can access its members
 

--- a/src/CAN2515.h
+++ b/src/CAN2515.h
@@ -7,8 +7,8 @@
 
 // header files
 
-#include <Controller.h>               // abstract base class
-#include <CAN2515.h>           // header for this class
+#include <Controller.h>
+#include <CanTransport.h>
 #include <ACAN2515.h>           // ACAN2515 library
 #include <SPI.h>
 
@@ -29,12 +29,11 @@ static const uint32_t OSCFREQ = 16000000UL;                 // crystal frequency
 /// to support the MCP2515/25625 CAN controllers
 //
 
-class CAN2515 : public Transport
+class CAN2515 : public CanTransport
 {
 public:
 
   CAN2515();
-  void setController(Controller * ctrl) override { this->controller = ctrl; }
 
   // these methods are declared virtual in the base class and must be implemented by the derived class
 #ifdef ARDUINO_ARCH_RP2040
@@ -43,7 +42,7 @@ public:
   bool begin(bool poll = false, SPIClass spi = SPI);
 #endif
   bool available() override;
-  CANFrame getNextMessage() override;
+  CANMessage getNextCanMessage();
   bool sendMessage(CANFrame *msg, bool rtr = false, bool ext = false, byte priority = DEFAULT_PRIORITY) override;    // note default arguments
   void reset() override;
 
@@ -66,7 +65,6 @@ public:
   unsigned int _numMsgsSent, _numMsgsRcvd;
 
 private:
-  Controller * controller;
   unsigned long _osc_freq;
   byte _csPin, _intPin;
   byte _num_rx_buffers, _num_tx_buffers;

--- a/src/CanService.cpp
+++ b/src/CanService.cpp
@@ -17,145 +17,18 @@ void CanService::setController(Controller *cntrl)
   this->module_config = cntrl->getModuleConfig();
 }
 
-//
-/// extract CANID from CAN frame header
-//
-inline byte getCANID(unsigned long header)
-{
-  return header & 0x7f;
-}
-
-//
-/// if in Normal mode, initiate a CAN ID enumeration cycle
-//
 void CanService::startCANenumeration(bool fromENUM)
 {
-  // initiate CAN bus enumeration cycle, either due to ENUM opcode, ID clash, or user button press
-
-  // DEBUG_SERIAL << F("> beginning self-enumeration cycle") << endl;
-
-  // set global variables
-  bCANenum = true;                  // we are enumerating
-  CANenumTime = millis();           // the cycle start time
-  memset(enum_responses, 0, sizeof(enum_responses));
-  startedFromEnumMessage = fromENUM;
-
-  // send zero-length RTR frame
-  CANFrame msg;
-  msg.len = 0;
-  controller->sendMessage(&msg, true, false);          // fixed arg order in v 1.1.4, RTR - true, ext = false
-
-  // DEBUG_SERIAL << F("> enumeration cycle initiated") << endl;
-}
-
-void CanService::checkCANenumTimout()
-{
-  //
-  /// check the 100ms CAN enumeration cycle timer
-  //
-  if (bCANenum && (millis() - CANenumTime) >= 100)
-  {
-    // enumeration timer has expired -- stop enumeration and process the responses
-
-    // DEBUG_SERIAL << F("> enum cycle complete at ") << millis() << F(", start = ") << CANenumTime << F(", duration = ") << (millis() - CANenumTime) << endl;
-    // DEBUG_SERIAL << F("> processing received responses") << endl;
-
-    byte selected_id = findFreeCanId();
-
-    // DEBUG_SERIAL << F("> lowest available CAN id = ") << selected_id << endl;
-
-    bCANenum = false;
-
-    // store the new CAN ID
-    module_config->setCANID(selected_id);
-
-    // send NNACK if initiated by ENUM request.
-    if (startedFromEnumMessage)
-    {
-      controller->sendMessageWithNN(OPC_NNACK);
-    }
-  }
-}
-
-byte CanService::findFreeCanId()
-{
-  // iterate through the 128 bit field
-  for (byte i = 0; i < 16; i++)
-  {
-    // ignore if this byte is all 1's -> there are no unused IDs in this group of numbers
-    if (enum_responses[i] == 0xff)
-    {
-      continue;
-    }
-
-    // for each bit in the byte
-    for (byte b = 0; b < 8; b++)
-    {
-      // ignore first bit of first byte -- CAN ID zero is not used for nodes
-      if (i == 0 && b == 0) {
-        continue;
-      }
-
-      // if the bit is not set
-      if (bitRead(enum_responses[i], b) == 0)
-      {
-        byte selected_id = ((i * 8) + b);
-        // DEBUG_SERIAL << F("> bit ") << b << F(" of byte ") << i << F(" is not set, first free CAN ID = ") << selected_id << endl;
-        return selected_id;
-      }
-    }
-  }
-
-  return 1;     // default if no responses from other modules
+  canTransport->startCANenumeration(fromENUM);
 }
 
 void CanService::process(UserInterface::RequestedAction requestedAction)
 {
-  if (enumeration_required || requestedAction == UserInterface::ENUMERATION)
-  {
-    // DEBUG_SERIAL << "> enumeration flag set" << endl;
-    enumeration_required = false;
-    startCANenumeration();
-  }
-
-  checkCANenumTimout();
+  canTransport->process(requestedAction);
 }
 
 Processed CanService::handleRawMessage(CANFrame *msg)
 {
-  byte remoteCANID = getCANID(msg->id);
-
-  // is this a CANID enumeration request from another node (RTR set) ?
-  if (msg->rtr)
-  {
-    // DEBUG_SERIAL << F("> CANID enumeration RTR from CANID = ") << remoteCANID << endl;
-    // send an empty message to show our CANID
-    msg->len = 0;
-    controller->sendMessage(msg);
-    return PROCESSED;
-  }
-
-  /// set flag if we find a CANID conflict with the frame's producer
-  /// doesn't apply to RTR or zero-length frames, so as not to trigger an enumeration loop
-  if (remoteCANID == module_config->CANID && msg->len > 0)
-  {
-    // DEBUG_SERIAL << F("> CAN id clash, enumeration required") << endl;
-    enumeration_required = true;
-  }
-
-  // are we enumerating CANIDs ?
-  if (bCANenum && msg->len == 0)
-  {
-    // store this response in the responses array
-    if (remoteCANID > 0)
-    {
-      // fix to correctly record the received CANID
-      bitWrite(enum_responses[(remoteCANID / 8)], remoteCANID % 8, 1);
-      // DEBUG_SERIAL << F("> stored CANID ") << remoteCANID << F(" at index = ") << (remoteCANID / 8) << F(", bit = ") << (remoteCANID % 8) << endl;
-    }
-
-    return PROCESSED;
-  }
 
   return NOT_PROCESSED;
 }
@@ -206,12 +79,10 @@ Processed CanService::handleSetCANID(const CANFrame *msg, unsigned int nn)
 
 Processed CanService::handleEnumeration(const CANFrame *msg, unsigned int nn)
 {
-  byte remoteCANID = getCANID(msg->id);
-
   // DEBUG_SERIAL << F("> ENUM message for nn = ") << nn << F(" from CANID = ") << remoteCANID << endl;
   // DEBUG_SERIAL << F("> my nn = ") << module_config->nodeNum << endl;
 
-  if (nn == module_config->nodeNum && remoteCANID != module_config->CANID && !bCANenum)
+  if (nn == module_config->nodeNum)
   {
     // DEBUG_SERIAL << F("> initiating enumeration") << endl;
     startCANenumeration(true);

--- a/src/CanService.h
+++ b/src/CanService.h
@@ -7,6 +7,7 @@
 
 #include "Service.h"
 #include "UserInterface.h"
+#include "CanTransport.h"
 #include <vlcbdefs.hpp>
 
 namespace VLCB
@@ -18,6 +19,7 @@ class CanService : public Service
 {
 
 public:
+  CanService(CanTransport * tpt) : canTransport(tpt) {}
 
   virtual void setController(Controller *cntrl) override;
   virtual byte getServiceID() override { return SERVICE_ID_CAN; }
@@ -33,15 +35,7 @@ private:
 
   Controller *controller;
   Configuration * module_config;  // Shortcut to reduce indirection code.
-
-  bool enumeration_required = false;
-  bool bCANenum = false;
-  bool startedFromEnumMessage = false;
-  unsigned long CANenumTime;
-  byte enum_responses[16];     // 128 bits for storing CAN ID enumeration results
-
-  void checkCANenumTimout();
-  byte findFreeCanId();
+  CanTransport * canTransport;
 
   Processed handleEnumeration(const CANFrame *msg, unsigned int nn);
   Processed handleSetCANID(const CANFrame *msg, unsigned int nn);

--- a/src/CanTransport.cpp
+++ b/src/CanTransport.cpp
@@ -1,0 +1,174 @@
+//  Copyright (C) Sven Rosvall (sven@rosvall.ie)
+//  This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+//  Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+//  The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0
+
+#include "CanTransport.h"
+#include "Controller.h"
+
+namespace VLCB
+{
+
+//
+/// extract CANID from CAN frame header
+//
+inline byte getCANID(unsigned long header)
+{
+  return header & 0x7f;
+}
+
+//
+/// if in Normal mode, initiate a CAN ID enumeration cycle
+//
+void CanTransport::startCANenumeration(bool fromENUM)
+{
+  if (bCANenum)
+  {
+    // already enumerating.
+    return;
+  }
+  // initiate CAN bus enumeration cycle, either due to ENUM opcode, ID clash, or user button press
+
+  // DEBUG_SERIAL << F("> beginning self-enumeration cycle") << endl;
+
+  // set global variables
+  bCANenum = true;                  // we are enumerating
+  CANenumTime = millis();           // the cycle start time
+  memset(enum_responses, 0, sizeof(enum_responses));
+  startedFromEnumMessage = fromENUM;
+
+  // send zero-length RTR frame
+  CANFrame msg;
+  msg.len = 0;
+  controller->sendMessage(&msg, true, false);          // fixed arg order in v 1.1.4, RTR - true, ext = false
+
+  // DEBUG_SERIAL << F("> enumeration cycle initiated") << endl;
+}
+
+CANFrame CanTransport::getNextMessage()
+{
+  CANMessage canMsg = getNextCanMessage();
+  CANFrame message;
+  //message.len = -1;
+
+  // is this a CANID enumeration request from another node (RTR set) ?
+  if (canMsg.rtr)
+  {
+    // DEBUG_SERIAL << F("> CANID enumeration RTR from CANID = ") << remoteCANID << endl;
+    // send an empty canMsg to show our CANID
+    message.len = 0;
+    controller->sendMessage(&message);
+    
+    message.len = -1;
+    return message;
+  }
+
+  byte remoteCANID = getCANID(canMsg.id);
+
+  /// set flag if we find a CANID conflict with the frame's producer
+  /// doesn't apply to RTR or zero-length frames, so as not to trigger an enumeration loop
+  if (remoteCANID == controller->getModuleCANID() && canMsg.len > 0)
+  {
+    // DEBUG_SERIAL << F("> CAN id clash, enumeration required") << endl;
+    enumeration_required = true;
+  }
+
+  // are we enumerating CANIDs ?
+  if (bCANenum && canMsg.len == 0)
+  {
+    // store this response in the responses array
+    if (remoteCANID > 0)
+    {
+      // fix to correctly record the received CANID
+      bitWrite(enum_responses[(remoteCANID / 8)], remoteCANID % 8, 1);
+      // DEBUG_SERIAL << F("> stored CANID ") << remoteCANID << F(" at index = ") << (remoteCANID / 8) << F(", bit = ") << (remoteCANID % 8) << endl;
+    }
+
+    message.len = -1;
+    return message;
+  }
+
+  // The message is a real message.
+  message.id = canMsg.id;
+  message.len = canMsg.len;
+  message.rtr = canMsg.rtr;
+  message.ext = canMsg.ext;
+  memcpy(message.data, canMsg.data, canMsg.len);
+
+  return message;
+}
+
+void CanTransport::checkCANenumTimout()
+{
+  //
+  /// check the 100ms CAN enumeration cycle timer
+  //
+  if (bCANenum && (millis() - CANenumTime) >= 100)
+  {
+    // enumeration timer has expired -- stop enumeration and process the responses
+
+    // DEBUG_SERIAL << F("> enum cycle complete at ") << millis() << F(", start = ") << CANenumTime << F(", duration = ") << (millis() - CANenumTime) << endl;
+    // DEBUG_SERIAL << F("> processing received responses") << endl;
+
+    byte selected_id = findFreeCanId();
+
+    // DEBUG_SERIAL << F("> lowest available CAN id = ") << selected_id << endl;
+
+    bCANenum = false;
+
+    // store the new CAN ID
+    controller->getModuleConfig()->setCANID(selected_id);
+
+    // send NNACK if initiated by ENUM request.
+    if (startedFromEnumMessage)
+    {
+      controller->sendMessageWithNN(OPC_NNACK);
+    }
+  }
+}
+
+byte CanTransport::findFreeCanId()
+{
+  // iterate through the 128 bit field
+  for (byte i = 0; i < 16; i++)
+  {
+    // ignore if this byte is all 1's -> there are no unused IDs in this group of numbers
+    if (enum_responses[i] == 0xff)
+    {
+      continue;
+    }
+
+    // for each bit in the byte
+    for (byte b = 0; b < 8; b++)
+    {
+      // ignore first bit of first byte -- CAN ID zero is not used for nodes
+      if (i == 0 && b == 0) {
+        continue;
+      }
+
+      // if the bit is not set
+      if (bitRead(enum_responses[i], b) == 0)
+      {
+        byte selected_id = ((i * 8) + b);
+        // DEBUG_SERIAL << F("> bit ") << b << F(" of byte ") << i << F(" is not set, first free CAN ID = ") << selected_id << endl;
+        return selected_id;
+      }
+    }
+  }
+
+  return 1;     // default if no responses from other modules
+}
+
+void CanTransport::process(UserInterface::RequestedAction requestedAction)
+{
+  if (enumeration_required || requestedAction == UserInterface::ENUMERATION)
+  {
+    // DEBUG_SERIAL << "> enumeration flag set" << endl;
+    enumeration_required = false;
+    startCANenumeration();
+  }
+
+  checkCANenumTimout();
+}
+
+}

--- a/src/CanTransport.cpp
+++ b/src/CanTransport.cpp
@@ -51,6 +51,15 @@ CANFrame CanTransport::getNextMessage()
   CANFrame message;
   //message.len = -1;
 
+  // is this an extended frame ? we currently ignore these as bootloader, etc data may confuse us !
+  if (canMsg.ext)
+  {
+    // DEBUG_SERIAL << F("> extended frame ignored, from CANID = ") << remoteCANID << endl;
+
+    message.len = -1;
+    return message;
+  }
+
   // is this a CANID enumeration request from another node (RTR set) ?
   if (canMsg.rtr)
   {
@@ -58,7 +67,7 @@ CANFrame CanTransport::getNextMessage()
     // send an empty canMsg to show our CANID
     message.len = 0;
     controller->sendMessage(&message);
-    
+
     message.len = -1;
     return message;
   }
@@ -91,8 +100,6 @@ CANFrame CanTransport::getNextMessage()
   // The message is a real message.
   message.id = canMsg.id;
   message.len = canMsg.len;
-  message.rtr = canMsg.rtr;
-  message.ext = canMsg.ext;
   memcpy(message.data, canMsg.data, canMsg.len);
 
   return message;

--- a/src/CanTransport.cpp
+++ b/src/CanTransport.cpp
@@ -98,7 +98,6 @@ CANFrame CanTransport::getNextMessage()
   }
 
   // The message is a real message.
-  message.id = canMsg.id;
   message.len = canMsg.len;
   memcpy(message.data, canMsg.data, canMsg.len);
 

--- a/src/CanTransport.cpp
+++ b/src/CanTransport.cpp
@@ -40,7 +40,8 @@ void CanTransport::startCANenumeration(bool fromENUM)
   // send zero-length RTR frame
   CANFrame msg;
   msg.len = 0;
-  controller->sendMessage(&msg, true, false);          // fixed arg order in v 1.1.4, RTR - true, ext = false
+  sendMessage(&msg, true, false);
+  controller->indicateActivity();
 
   // DEBUG_SERIAL << F("> enumeration cycle initiated") << endl;
 }
@@ -66,7 +67,8 @@ CANFrame CanTransport::getNextMessage()
     // DEBUG_SERIAL << F("> CANID enumeration RTR from CANID = ") << remoteCANID << endl;
     // send an empty canMsg to show our CANID
     message.len = 0;
-    controller->sendMessage(&message);
+    sendMessage(&message);
+    controller->indicateActivity();
 
     message.len = -1;
     return message;

--- a/src/CanTransport.h
+++ b/src/CanTransport.h
@@ -23,7 +23,8 @@ public:
   virtual CANFrame getNextMessage() override;
   virtual CANMessage getNextCanMessage() = 0;
 
-  virtual bool sendMessage(CANFrame *msg, bool rtr = false, bool ext = false, byte priority = DEFAULT_PRIORITY) override;
+  virtual bool sendMessage(CANFrame *msg) override;
+  bool sendRtrMessage();
   virtual bool sendCanMessage(CANMessage *msg) = 0;
 
   void startCANenumeration(bool fromENUM = false);

--- a/src/CanTransport.h
+++ b/src/CanTransport.h
@@ -1,0 +1,42 @@
+//  Copyright (C) Sven Rosvall (sven@rosvall.ie)
+//  This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+//  Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+//  The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0
+
+#pragma once
+
+#include <Arduino.h>
+#include "Transport.h"
+#include "ACAN2515.h"
+#include "UserInterface.h"
+
+namespace VLCB
+{
+
+class CanTransport : public Transport
+{
+public:
+  void setController(Controller *ctrl) override { this->controller = ctrl; }
+
+  void process(UserInterface::RequestedAction requestedAction);
+  CANFrame getNextMessage();
+
+  virtual CANMessage getNextCanMessage() = 0;
+  void startCANenumeration(bool fromENUM = false);
+
+protected: // TODO: CAN2515 needs access to controller during refactoring.
+  Controller *controller;
+
+private:
+  void checkCANenumTimout();
+  byte findFreeCanId();
+
+  bool enumeration_required = false;
+  bool bCANenum = false;
+  bool startedFromEnumMessage = false;
+  unsigned long CANenumTime;
+  byte enum_responses[16];     // 128 bits for storing CAN ID enumeration results
+
+};
+
+}

--- a/src/CanTransport.h
+++ b/src/CanTransport.h
@@ -19,9 +19,13 @@ public:
   void setController(Controller *ctrl) override { this->controller = ctrl; }
 
   void process(UserInterface::RequestedAction requestedAction);
-  CANFrame getNextMessage();
 
+  virtual CANFrame getNextMessage() override;
   virtual CANMessage getNextCanMessage() = 0;
+
+  virtual bool sendMessage(CANFrame *msg, bool rtr = false, bool ext = false, byte priority = DEFAULT_PRIORITY) override;
+  virtual bool sendCanMessage(CANMessage *msg) = 0;
+
   void startCANenumeration(bool fromENUM = false);
 
 protected: // TODO: CAN2515 needs access to controller during refactoring.

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -117,22 +117,6 @@ void Controller::setName(const unsigned char *mname)
 }
 
 //
-/// is this an Extended CAN frame ?
-//
-bool Controller::isExt(CANFrame *amsg)
-{
-  return (amsg->ext);
-}
-
-//
-/// is this a Remote frame ?
-//
-bool Controller::isRTR(CANFrame *amsg)
-{
-  return (amsg->rtr);
-}
-
-//
 /// set the Controller LEDs to indicate the current mode
 //
 
@@ -225,13 +209,6 @@ void Controller::process(byte num_messages)
     }
 
     indicateActivity();
-
-    // is this an extended frame ? we currently ignore these as bootloader, etc data may confuse us !
-    if (msg.ext)
-    {
-      // DEBUG_SERIAL << F("> extended frame ignored, from CANID = ") << remoteCANID << endl;
-      continue;
-    }
 
     //
     /// process the message opcode

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -206,6 +206,12 @@ void Controller::process(byte num_messages)
     CANFrame msg = transport->getNextMessage();
     // DEBUG_SERIAL << "> Received a message" << endl;
 
+    if (msg.len < 0)
+    {
+      // received msg was something CAN specific, ignore it.
+      continue;
+    }
+
     callFrameHandler(&msg);
 
     for (Service * service : services)

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -27,8 +27,6 @@ namespace VLCB
 struct CANFrame
 {
   uint32_t id;
-  bool ext;
-  bool rtr;
   int8_t len; // Value 0-7 or -1 for messages handled in CanTransport
   uint8_t data[8];
 };
@@ -72,8 +70,6 @@ public:
 
   void startCANenumeration();
   byte getModuleCANID() { return module_config->CANID; }
-  static bool isExt(CANFrame *msg);
-  static bool isRTR(CANFrame *msg);
   void process(byte num_messages = 3);
   void indicateMode(byte mode);
   void indicateActivity();

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -50,10 +50,10 @@ public:
   void setParamFlag(unsigned char flag, bool b);
   unsigned char getParam(unsigned int param) { return _mparams[param]; }
 
-  bool sendMessage(CANFrame *msg, bool rtr = false, bool ext = false, byte priority = DEFAULT_PRIORITY)
+  bool sendMessage(CANFrame *msg)
   {
     indicateActivity();
-    return transport->sendMessage(msg, rtr, ext, priority);
+    return transport->sendMessage(msg);
   }
   
   void begin();

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -26,7 +26,6 @@ namespace VLCB
 //
 struct CANFrame
 {
-  uint32_t id;
   int8_t len; // Value 0-7 or -1 for messages handled in CanTransport
   uint8_t data[8];
 };

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -29,7 +29,7 @@ struct CANFrame
   uint32_t id;
   bool ext;
   bool rtr;
-  uint8_t len;
+  int8_t len; // Value 0-7 or -1 for messages handled in CanTransport
   uint8_t data[8];
 };
 

--- a/src/LongMessageService.cpp
+++ b/src/LongMessageService.cpp
@@ -177,7 +177,6 @@ void LongMessageService::processReceivedMessageFragment(const CANFrame *frame)
             memset(_receive_buffer, 0, _receive_buffer_len);
             _receive_buffer_index = 0;
             _expected_next_receive_sequence_num = 0;
-            _sender_canid = (frame->id & 0x7f);
             // DEBUG_SERIAL << F("> L: received header packet for stream id = ") << _receive_stream_id << F(", message length = ") << _incoming_message_length << F(", user buffer len = ") << _receive_buffer_len << endl;
             break;
           }
@@ -194,77 +193,67 @@ void LongMessageService::processReceivedMessageFragment(const CANFrame *frame)
   {
     // we're part way through receiving a message
 
-    if ((frame->id & 0x7f) == _sender_canid)
+    // it's the same sender CANID
+
+    if (frame->data[1] == _receive_stream_id)
     {
-      // it's the same sender CANID
+      // it's the same stream id
 
-      if (frame->data[1] == _receive_stream_id)
+      if (frame->data[2] == _expected_next_receive_sequence_num)
       {
-        // it's the same stream id
+        // and it's the expected sequence id
 
-        if (frame->data[2] == _expected_next_receive_sequence_num)
+        // DEBUG_SERIAL << F("> L: received continuation packet, seq = ") << _expected_next_receive_sequence_num << endl;
+
+        // for each of the maximum five payload bytes, up to the total message length and the user buffer length
+        for (j = 0; j < 5; j++)
         {
-          // and it's the expected sequence id
+          _receive_buffer[_receive_buffer_index] = frame->data[j + 3];                // take the next byte
+          ++_receive_buffer_index;                                                    // increment the buffer index
+          ++_incoming_bytes_received;
+          // DEBUG_SERIAL << F("> L: processing received data byte = ") << (char)frame->data[j + 3] << endl;
 
-          // DEBUG_SERIAL << F("> L: received continuation packet, seq = ") << _expected_next_receive_sequence_num << endl;
-
-          // for each of the maximum five payload bytes, up to the total message length and the user buffer length
-          for (j = 0; j < 5; j++)
+          // if we have read the entire message
+          if (_incoming_bytes_received >= _incoming_message_length)
           {
-            _receive_buffer[_receive_buffer_index] = frame->data[j + 3];                // take the next byte
-            ++_receive_buffer_index;                                                    // increment the buffer index
-            ++_incoming_bytes_received;
-            // DEBUG_SERIAL << F("> L: processing received data byte = ") << (char)frame->data[j + 3] << endl;
+            // DEBUG_SERIAL << F("> L: bytes processed = ") << _incoming_bytes_received << F(", message data has been fully consumed") << endl;
+            (void) (*_messagehandler)(_receive_buffer, _receive_buffer_index, _receive_stream_id,
+                                      LONG_MESSAGE_COMPLETE);
+            _receive_buffer_index = 0;
+            memset(_receive_buffer, 0, _receive_buffer_len);
+            break;
 
-            // if we have read the entire message
-            if (_incoming_bytes_received >= _incoming_message_length)
-            {
-              // DEBUG_SERIAL << F("> L: bytes processed = ") << _incoming_bytes_received << F(", message data has been fully consumed") << endl;
-              (void) (*_messagehandler)(_receive_buffer, _receive_buffer_index, _receive_stream_id,
-                                        LONG_MESSAGE_COMPLETE);
-              _receive_buffer_index = 0;
-              memset(_receive_buffer, 0, _receive_buffer_len);
-              break;
-
-              // if the user buffer is full, give the user what we have so far
-            }
-            else if (_receive_buffer_index >= _receive_buffer_len)
-            {
-              // DEBUG_SERIAL << F("> L: user buffer is full") << endl;
-              (void) (*_messagehandler)(_receive_buffer, _receive_buffer_index, _receive_stream_id,
-                                        LONG_MESSAGE_INCOMPLETE);
-              _receive_buffer_index = 0;
-              memset(_receive_buffer, 0, _receive_buffer_len);
-            }
+            // if the user buffer is full, give the user what we have so far
           }
-
+          else if (_receive_buffer_index >= _receive_buffer_len)
+          {
+            // DEBUG_SERIAL << F("> L: user buffer is full") << endl;
+            (void) (*_messagehandler)(_receive_buffer, _receive_buffer_index, _receive_stream_id,
+                                      LONG_MESSAGE_INCOMPLETE);
+            _receive_buffer_index = 0;
+            memset(_receive_buffer, 0, _receive_buffer_len);
+          }
         }
-        else
-        {
-          // it's the wrong sequence id
 
-          // DEBUG_SERIAL << F("> L: ERROR: expected receive sequence num = ") << _expected_next_receive_sequence_num << F(" but got = ") << frame->data[2] << endl;
-          (void) (*_messagehandler)(_receive_buffer, _receive_buffer_index, _receive_stream_id,
-                                    LONG_MESSAGE_SEQUENCE_ERROR);
-          _incoming_message_length = 0;
-          _incoming_bytes_received = 0;
-          _is_receiving = false;
-        }
       }
       else
       {
-        // probably another stream in progress - we'll ignore it as we don't support concurrent streams
+        // it's the wrong sequence id
 
-        // DEBUG_SERIAL << F("> L: ignoring unexpected stream id =") << _receive_stream_id << F(", got = ") << frame->data[2] << endl;
+        // DEBUG_SERIAL << F("> L: ERROR: expected receive sequence num = ") << _expected_next_receive_sequence_num << F(" but got = ") << frame->data[2] << endl;
+        (void) (*_messagehandler)(_receive_buffer, _receive_buffer_index, _receive_stream_id,
+                                  LONG_MESSAGE_SEQUENCE_ERROR);
+        _incoming_message_length = 0;
+        _incoming_bytes_received = 0;
+        _is_receiving = false;
       }
     }
     else
     {
-      // a different sender CANID - ignore the fragment
+      // probably another stream in progress - we'll ignore it as we don't support concurrent streams
 
-      // DEBUG_SERIAL << F("> L: ignoring fragment from unexpected CANID") << endl;
+      // DEBUG_SERIAL << F("> L: ignoring unexpected stream id =") << _receive_stream_id << F(", got = ") << frame->data[2] << endl;
     }
-
 	}	// it's a continuation fragment
 
 	// the sequence number may wrap from 255 to 0, which is absolutely fine
@@ -610,7 +599,6 @@ void LongMessageServiceEx::processReceivedMessageFragment(const CANFrame *frame)
             memset(_receive_context[i]->buffer, 0, _receive_buffer_len);
             _receive_context[i]->receive_buffer_index = 0;
             _receive_context[i]->expected_next_receive_sequence_num = 1;
-            _receive_context[i]->sender_canid = (frame->id & 0x7f);
             _receive_context[i]->last_fragment_received = millis();
             // DEBUG_SERIAL << F("> Lex: received header packet for stream id = ") << _receive_context[i]->receive_stream_id << F(", message length = ") << _receive_context[i]->incoming_message_length << endl;
           }
@@ -637,8 +625,7 @@ void LongMessageServiceEx::processReceivedMessageFragment(const CANFrame *frame)
     // find a matching receive context, using the stream ID and sender CANID
     for (i = 0; i < _num_receive_contexts; i++)
     {
-      if (_receive_context[i]->in_use && _receive_context[i]->receive_stream_id == frame->data[1] &&
-          _receive_context[i]->sender_canid == (frame->id & 0x7f))
+      if (_receive_context[i]->in_use && _receive_context[i]->receive_stream_id == frame->data[1])
       {
         // DEBUG_SERIAL << F("> Lex: found matching receive context = ") << i << endl;
         break;

--- a/src/LongMessageService.cpp
+++ b/src/LongMessageService.cpp
@@ -299,7 +299,7 @@ bool LongMessageService::sendMessageFragment(CANFrame * frame, const byte priori
 	frame->len = 8;
 	frame->data[0] = OPC_DTXC;
 
-	return (controller->sendMessage(frame, false, false, priority));
+	return (controller->sendMessage(frame));
 }
 
 //

--- a/src/LongMessageService.h
+++ b/src/LongMessageService.h
@@ -61,7 +61,7 @@ protected:
   bool _is_receiving = false;
   byte *_send_buffer, *_receive_buffer;
   byte _send_stream_id = 0, _receive_stream_id = 0, *_stream_ids = NULL, _num_stream_ids = 0;
-  byte _send_priority = DEFAULT_PRIORITY, _msg_delay = LONG_MESSAGE_DEFAULT_DELAY, _sender_canid = 0;
+  byte _send_priority = DEFAULT_PRIORITY, _msg_delay = LONG_MESSAGE_DEFAULT_DELAY;
   unsigned int _send_buffer_len = 0, _incoming_message_length = 0, _receive_buffer_len = 0, _receive_buffer_index = 0;
   unsigned int _send_buffer_index = 0, _incoming_message_crc = 0, _incoming_bytes_received = 0;
   unsigned int _receive_timeout = LONG_MESSAGE_RECEIVE_TIMEOUT, _send_sequence_num = 0, _expected_next_receive_sequence_num = 0;
@@ -78,7 +78,7 @@ protected:
 
 struct receive_context_t {
   bool in_use;
-  byte receive_stream_id, sender_canid;
+  byte receive_stream_id;
   byte *buffer;
   unsigned int receive_buffer_index, incoming_bytes_received, incoming_message_length, expected_next_receive_sequence_num, incoming_message_crc;
   unsigned long last_fragment_received;

--- a/src/Transport.h
+++ b/src/Transport.h
@@ -22,7 +22,7 @@ public:
   virtual void setController(Controller * ctrl) { }
   virtual bool available() = 0;
   virtual CANFrame getNextMessage() = 0;
-  virtual bool sendMessage(CANFrame *msg, bool rtr = false, bool ext = false, byte priority = DEFAULT_PRIORITY) = 0;
+  virtual bool sendMessage(CANFrame *msg) = 0;
   virtual void reset() = 0;
 };
 

--- a/test/MockCanTransport.cpp
+++ b/test/MockCanTransport.cpp
@@ -1,0 +1,48 @@
+//  Copyright (C) Sven Rosvall (sven@rosvall.ie)
+//  This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+//  Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+//  The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0
+//
+//
+
+#include <Controller.h>
+#include "MockCanTransport.h"
+
+bool MockCanTransport::available()
+{
+  return !incoming_messages.empty();
+}
+
+CANMessage MockCanTransport::getNextCanMessage()
+{
+  CANMessage msg = incoming_messages.front();
+  incoming_messages.pop_front();
+  return msg;
+}
+
+bool MockCanTransport::sendMessage(VLCB::CANFrame *msg, bool rtr, bool ext, byte priority)
+{
+  // Update the message the same way as CAN2515 does.
+  msg->id = controller->getModuleCANID();
+  msg->rtr = rtr;
+  msg->ext = ext;
+
+  sent_messages.push_back(*msg);
+  return true;
+}
+
+void MockCanTransport::reset()
+{
+
+}
+
+void MockCanTransport::setNextMessage(CANMessage msg)
+{
+  incoming_messages.push_back(msg);
+}
+
+void MockCanTransport::clearMessages()
+{
+  incoming_messages.clear();
+  sent_messages.clear();
+}

--- a/test/MockCanTransport.cpp
+++ b/test/MockCanTransport.cpp
@@ -20,13 +20,8 @@ CANMessage MockCanTransport::getNextCanMessage()
   return msg;
 }
 
-bool MockCanTransport::sendMessage(VLCB::CANFrame *msg, bool rtr, bool ext, byte priority)
+bool MockCanTransport::sendCanMessage(CANMessage *msg)
 {
-  // Update the message the same way as CAN2515 does.
-  msg->id = controller->getModuleCANID();
-  msg->rtr = rtr;
-  msg->ext = ext;
-
   sent_messages.push_back(*msg);
   return true;
 }

--- a/test/MockCanTransport.h
+++ b/test/MockCanTransport.h
@@ -20,12 +20,13 @@ class MockCanTransport : public VLCB::CanTransport
 public:
   virtual bool available() override;
   virtual CANMessage getNextCanMessage() override;
-  virtual bool sendMessage(VLCB::CANFrame *msg, bool rtr, bool ext, byte priority) override;
+  virtual bool sendCanMessage(CANMessage *msg) override;
+  
   virtual void reset() override;
 
   void setNextMessage(CANMessage msg);
   void clearMessages();
 
   std::deque<CANMessage> incoming_messages;
-  std::vector<VLCB::CANFrame> sent_messages;
+  std::vector<CANMessage> sent_messages;
 };

--- a/test/MockCanTransport.h
+++ b/test/MockCanTransport.h
@@ -1,0 +1,31 @@
+//  Copyright (C) Sven Rosvall (sven@rosvall.ie)
+//  This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+//  Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+//  The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0
+//
+//
+
+#pragma once
+
+#include <deque>
+#include <vector>
+#include "Transport.h"
+#include "Controller.h"
+#include "CanTransport.h"
+#include "ACAN2515.h"
+
+// This is to replace the hardware layer. It uses the CanTransport class for CAN processing.
+class MockCanTransport : public VLCB::CanTransport
+{
+public:
+  virtual bool available() override;
+  virtual CANMessage getNextCanMessage() override;
+  virtual bool sendMessage(VLCB::CANFrame *msg, bool rtr, bool ext, byte priority) override;
+  virtual void reset() override;
+
+  void setNextMessage(CANMessage msg);
+  void clearMessages();
+
+  std::deque<CANMessage> incoming_messages;
+  std::vector<VLCB::CANFrame> sent_messages;
+};

--- a/test/MockTransport.cpp
+++ b/test/MockTransport.cpp
@@ -25,7 +25,7 @@ VLCB::CANFrame MockTransport::getNextMessage()
   return frame;
 }
 
-bool MockTransport::sendMessage(VLCB::CANFrame *msg, bool rtr, bool ext, byte priority)
+bool MockTransport::sendMessage(VLCB::CANFrame *msg)
 {
   sent_messages.push_back(*msg);
   return true;

--- a/test/MockTransport.cpp
+++ b/test/MockTransport.cpp
@@ -29,8 +29,6 @@ bool MockTransport::sendMessage(VLCB::CANFrame *msg, bool rtr, bool ext, byte pr
 {
   // Update the message the same way as CAN2515 does.
   msg->id = controller->getModuleCANID();
-  msg->rtr = rtr;
-  msg->ext = ext;
 
   sent_messages.push_back(*msg);
   return true;

--- a/test/MockTransport.cpp
+++ b/test/MockTransport.cpp
@@ -27,9 +27,6 @@ VLCB::CANFrame MockTransport::getNextMessage()
 
 bool MockTransport::sendMessage(VLCB::CANFrame *msg, bool rtr, bool ext, byte priority)
 {
-  // Update the message the same way as CAN2515 does.
-  msg->id = controller->getModuleCANID();
-
   sent_messages.push_back(*msg);
   return true;
 }

--- a/test/MockTransport.h
+++ b/test/MockTransport.h
@@ -18,7 +18,7 @@ public:
   virtual void setController(VLCB::Controller *ctrl) override;
   virtual bool available() override;
   virtual VLCB::CANFrame getNextMessage() override;
-  virtual bool sendMessage(VLCB::CANFrame *msg, bool rtr, bool ext, byte priority) override;
+  virtual bool sendMessage(VLCB::CANFrame *msg) override;
   virtual void reset() override;
   void setNextMessage(VLCB::CANFrame msg);
   void clearMessages();

--- a/test/VlcbCommon.cpp
+++ b/test/VlcbCommon.cpp
@@ -13,9 +13,15 @@ std::unique_ptr<VLCB::Configuration> configuration;
 
 VLCB::Controller createController(const std::initializer_list<VLCB::Service *> services)
 {
+  mockTransport.reset(new MockTransport);
+
+  return createController(mockTransport.get(), services);
+}
+
+VLCB::Controller createController(VLCB::Transport * trp, const std::initializer_list<VLCB::Service *> services)
+{
   // Use pointers to objects to create the controller with.
   // Use unique_ptr so that next invocation deletes the previous objects.
-  mockTransport.reset(new MockTransport);
 
   mockUserInterface.reset(new MockUserInterface);
 
@@ -24,8 +30,7 @@ VLCB::Controller createController(const std::initializer_list<VLCB::Service *> s
 
   configuration.reset(new VLCB::Configuration(mockStorage.get()));
 
-  VLCB::Controller controller(mockUserInterface.get(), configuration.get(), mockTransport.get(),
-                              services);
+  VLCB::Controller controller(mockUserInterface.get(), configuration.get(), trp, services);
 
   configuration->EE_NVS_START = 10;
   configuration->EE_NUM_NVS = 4;

--- a/test/VlcbCommon.h
+++ b/test/VlcbCommon.h
@@ -17,4 +17,7 @@ extern std::unique_ptr<MockUserInterface> mockUserInterface;
 extern std::unique_ptr<MockTransport> mockTransport;
 extern std::unique_ptr<VLCB::Configuration> configuration;
 
+// Use MockTransport to mock out the whole transport part.
 VLCB::Controller createController(std::initializer_list<VLCB::Service *> services);
+// Use a provided transport.
+VLCB::Controller createController(VLCB::Transport * trp, std::initializer_list<VLCB::Service *> services);

--- a/test/testCanService.cpp
+++ b/test/testCanService.cpp
@@ -229,7 +229,7 @@ void testRtrMessage()
   assertEquals(1, mockCanTransport->sent_messages.size());
   assertEquals(0, mockCanTransport->sent_messages[0].len);
   assertEquals(false, mockCanTransport->sent_messages[0].rtr);
-  assertEquals(3, mockCanTransport->sent_messages[0].id);
+  assertEquals(3, mockCanTransport->sent_messages[0].id & 0x7F);
 }
 
 void testFindFreeCanidOnPopulatedBus()

--- a/test/testCanService.cpp
+++ b/test/testCanService.cpp
@@ -15,19 +15,25 @@
 #include "Parameters.h"
 #include "VlcbCommon.h"
 #include "ArduinoMock.hpp"
+#include "MockCanTransport.h"
 
 namespace
 {
 std::unique_ptr<VLCB::MinimumNodeService> minimumNodeService;
 
+// Use MockCanTransport to test CanTransport class.
+std::unique_ptr<MockCanTransport> mockCanTransport;
+
 VLCB::Controller createController()
 {
   minimumNodeService.reset(new VLCB::MinimumNodeService);
 
-  static std::unique_ptr<VLCB::CanService> canService;
-  canService.reset(new VLCB::CanService);
+  mockCanTransport.reset(new MockCanTransport);
 
-  return ::createController({minimumNodeService.get(), canService.get()});
+  static std::unique_ptr<VLCB::CanService> canService;
+  canService.reset(new VLCB::CanService(mockCanTransport.get()));
+
+  return ::createController(mockCanTransport.get(), {minimumNodeService.get(), canService.get()});
 }
 
 void testServiceDiscovery()
@@ -36,26 +42,26 @@ void testServiceDiscovery()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 0}};
-  mockTransport->setNextMessage(msg);
+  CANMessage msg = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 0}};
+  mockCanTransport->setNextMessage(msg);
 
   controller.process();
 
   // Verify sent messages.
-  assertEquals(3, mockTransport->sent_messages.size());
+  assertEquals(3, mockCanTransport->sent_messages.size());
 
-  assertEquals(OPC_SD, mockTransport->sent_messages[0].data[0]);
-  assertEquals(2, mockTransport->sent_messages[0].data[5]); // Number of services
+  assertEquals(OPC_SD, mockCanTransport->sent_messages[0].data[0]);
+  assertEquals(2, mockCanTransport->sent_messages[0].data[5]); // Number of services
 
-  assertEquals(OPC_SD, mockTransport->sent_messages[1].data[0]);
-  assertEquals(1, mockTransport->sent_messages[1].data[3]); // index
-  assertEquals(SERVICE_ID_MNS, mockTransport->sent_messages[1].data[4]); // service ID
-  assertEquals(1, mockTransport->sent_messages[1].data[5]); // version
+  assertEquals(OPC_SD, mockCanTransport->sent_messages[1].data[0]);
+  assertEquals(1, mockCanTransport->sent_messages[1].data[3]); // index
+  assertEquals(SERVICE_ID_MNS, mockCanTransport->sent_messages[1].data[4]); // service ID
+  assertEquals(1, mockCanTransport->sent_messages[1].data[5]); // version
 
-  assertEquals(OPC_SD, mockTransport->sent_messages[2].data[0]);
-  assertEquals(2, mockTransport->sent_messages[2].data[3]); // index
-  assertEquals(SERVICE_ID_CAN, mockTransport->sent_messages[2].data[4]); // service ID
-  assertEquals(1, mockTransport->sent_messages[2].data[5]); // version
+  assertEquals(OPC_SD, mockCanTransport->sent_messages[2].data[0]);
+  assertEquals(2, mockCanTransport->sent_messages[2].data[3]); // index
+  assertEquals(SERVICE_ID_CAN, mockCanTransport->sent_messages[2].data[4]); // service ID
+  assertEquals(1, mockCanTransport->sent_messages[2].data[5]); // version
 }
 
 void testServiceDiscoveryCanSvc()
@@ -64,16 +70,16 @@ void testServiceDiscoveryCanSvc()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 2}};
-  mockTransport->setNextMessage(msg);
+  CANMessage msg = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 2}};
+  mockCanTransport->setNextMessage(msg);
 
   controller.process();
 
   // Verify sent messages.
-  assertEquals(1, mockTransport->sent_messages.size());
-  assertEquals(OPC_ESD, mockTransport->sent_messages[0].data[0]);
-  assertEquals(2, mockTransport->sent_messages[0].data[3]); // index
-  assertEquals(SERVICE_ID_CAN, mockTransport->sent_messages[0].data[4]); // service ID
+  assertEquals(1, mockCanTransport->sent_messages.size());
+  assertEquals(OPC_ESD, mockCanTransport->sent_messages[0].data[0]);
+  assertEquals(2, mockCanTransport->sent_messages[0].data[3]); // index
+  assertEquals(SERVICE_ID_CAN, mockCanTransport->sent_messages[0].data[4]); // service ID
   // Not testing service data bytes.
 }
 
@@ -93,16 +99,16 @@ void testCanidEnumerationOnUserAction()
   mockUserInterface->setRequestedAction(VLCB::UserInterface::NONE);
 
   // Expect message to make other modules report their CANID's
-  assertEquals(1, mockTransport->sent_messages.size());
-  assertEquals(true, mockTransport->sent_messages[0].rtr);
-  assertEquals(0, mockTransport->sent_messages[0].len);
+  assertEquals(1, mockCanTransport->sent_messages.size());
+  assertEquals(true, mockCanTransport->sent_messages[0].rtr);
+  assertEquals(0, mockCanTransport->sent_messages[0].len);
 
   // Processing after enumeration timeout
   addMillis(101);
-  mockTransport->sent_messages.clear();
+  mockCanTransport->sent_messages.clear();
   controller.process();
 
-  assertEquals(0, mockTransport->sent_messages.size());
+  assertEquals(0, mockCanTransport->sent_messages.size());
 
   // Expect first available CANID
   assertEquals(1, controller.getModuleCANID());
@@ -123,25 +129,25 @@ void testCanidEnumerationOnSetUp()
   mockUserInterface->setRequestedAction(VLCB::UserInterface::NONE);
 
   // Expect message to make other modules report their CANID's
-  assertEquals(2, mockTransport->sent_messages.size());
+  assertEquals(2, mockCanTransport->sent_messages.size());
 
-  assertEquals(true, mockTransport->sent_messages[0].rtr);
-  assertEquals(0, mockTransport->sent_messages[0].len);
+  assertEquals(true, mockCanTransport->sent_messages[0].rtr);
+  assertEquals(0, mockCanTransport->sent_messages[0].len);
 
-  assertEquals(OPC_RQNN, mockTransport->sent_messages[1].data[0]);
-  assertEquals(0, mockTransport->sent_messages[1].data[1]);
-  assertEquals(0, mockTransport->sent_messages[1].data[2]);
+  assertEquals(OPC_RQNN, mockCanTransport->sent_messages[1].data[0]);
+  assertEquals(0, mockCanTransport->sent_messages[1].data[1]);
+  assertEquals(0, mockCanTransport->sent_messages[1].data[2]);
 
   // Processing after enumeration timeout
   addMillis(101);
-  mockTransport->sent_messages.clear();
+  mockCanTransport->sent_messages.clear();
   controller.process();
 
   // Expect first available CANID
   assertEquals(1, controller.getModuleCANID());
 
   // Expect no further messages
-  assertEquals(0, mockTransport->sent_messages.size());
+  assertEquals(0, mockCanTransport->sent_messages.size());
   
   // Note: RQNN shouldn't really be sent until a CANID has been set. 
   // But this works so going to leave as is.
@@ -153,23 +159,23 @@ void testCanidEnumerationOnENUM()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_ENUM, 0x01, 0x04, 2}};
-  mockTransport->setNextMessage(msg);
+  CANMessage msg = {0x11, false, false, 4, {OPC_ENUM, 0x01, 0x04, 2}};
+  mockCanTransport->setNextMessage(msg);
 
   controller.process();
 
   // Expect message to make other modules report their CANID's
-  assertEquals(1, mockTransport->sent_messages.size());
-  assertEquals(true, mockTransport->sent_messages[0].rtr);
-  assertEquals(0, mockTransport->sent_messages[0].len);
+  assertEquals(1, mockCanTransport->sent_messages.size());
+  assertEquals(true, mockCanTransport->sent_messages[0].rtr);
+  assertEquals(0, mockCanTransport->sent_messages[0].len);
 
   // Processing after enumeration timeout
   addMillis(101);
-  mockTransport->sent_messages.clear();
+  mockCanTransport->sent_messages.clear();
   controller.process();
 
-  assertEquals(1, mockTransport->sent_messages.size());
-  assertEquals(OPC_NNACK, mockTransport->sent_messages[0].data[0]);
+  assertEquals(1, mockCanTransport->sent_messages.size());
+  assertEquals(OPC_NNACK, mockCanTransport->sent_messages[0].data[0]);
 
   // Expect first available CANID
   assertEquals(1, controller.getModuleCANID());
@@ -182,26 +188,26 @@ void testCanidEnumerationOnConflict()
   VLCB::Controller controller = createController();
   controller.getModuleConfig()->setCANID(3);
 
-  VLCB::CANFrame msg = {3, false, false, 1, {OPC_RQNP}};
-  mockTransport->setNextMessage(msg);
+  CANMessage msg = {3, false, false, 1, {OPC_RQNP}};
+  mockCanTransport->setNextMessage(msg);
 
   controller.process();
-  assertEquals(0, mockTransport->sent_messages.size());
+  assertEquals(0, mockCanTransport->sent_messages.size());
   
   // Collision above only sets a flag. Enumeration happens next.
   controller.process();
 
   // Expect message to make other modules report their CANID's
-  assertEquals(1, mockTransport->sent_messages.size());
-  assertEquals(true, mockTransport->sent_messages[0].rtr);
-  assertEquals(0, mockTransport->sent_messages[0].len);
+  assertEquals(1, mockCanTransport->sent_messages.size());
+  assertEquals(true, mockCanTransport->sent_messages[0].rtr);
+  assertEquals(0, mockCanTransport->sent_messages[0].len);
 
   // Processing after enumeration timeout
   addMillis(101);
-  mockTransport->sent_messages.clear();
+  mockCanTransport->sent_messages.clear();
   controller.process();
 
-  assertEquals(0, mockTransport->sent_messages.size());
+  assertEquals(0, mockCanTransport->sent_messages.size());
 
   // Expect first available CANID
   assertEquals(1, controller.getModuleCANID());
@@ -214,16 +220,16 @@ void testRtrMessage()
   VLCB::Controller controller = createController();
   controller.getModuleConfig()->CANID = 3;
 
-  VLCB::CANFrame msg = {0x11, false, true, 0, {}};
-  mockTransport->setNextMessage(msg);
+  CANMessage msg = {0x11, false, true, 0, {}};
+  mockCanTransport->setNextMessage(msg);
 
   controller.process();
 
   // Verify sent messages.
-  assertEquals(1, mockTransport->sent_messages.size());
-  assertEquals(0, mockTransport->sent_messages[0].len);
-  assertEquals(false, mockTransport->sent_messages[0].rtr);
-  assertEquals(3, mockTransport->sent_messages[0].id);
+  assertEquals(1, mockCanTransport->sent_messages.size());
+  assertEquals(0, mockCanTransport->sent_messages[0].len);
+  assertEquals(false, mockCanTransport->sent_messages[0].rtr);
+  assertEquals(3, mockCanTransport->sent_messages[0].id);
 }
 
 void testFindFreeCanidOnPopulatedBus()
@@ -242,27 +248,27 @@ void testFindFreeCanidOnPopulatedBus()
   mockUserInterface->setRequestedAction(VLCB::UserInterface::NONE);
 
   // Expect message to make other modules report their CANID's
-  assertEquals(1, mockTransport->sent_messages.size());
-  assertEquals(true, mockTransport->sent_messages[0].rtr);
-  assertEquals(0, mockTransport->sent_messages[0].len);
-  mockTransport->sent_messages.clear();
+  assertEquals(1, mockCanTransport->sent_messages.size());
+  assertEquals(true, mockCanTransport->sent_messages[0].rtr);
+  assertEquals(0, mockCanTransport->sent_messages[0].len);
+  mockCanTransport->sent_messages.clear();
 
   // Simulate other nodes
   for (byte remoteCanid = 1 ; remoteCanid <= 19 ; ++remoteCanid)
   {
-    VLCB::CANFrame msg = {remoteCanid, false, false, 0, {}};
-    mockTransport->setNextMessage(msg);
+    CANMessage msg = {remoteCanid, false, false, 0, {}};
+    mockCanTransport->setNextMessage(msg);
     controller.process();
-    mockTransport->incoming_messages.clear();
+    mockCanTransport->incoming_messages.clear();
   }
-  assertEquals(0, mockTransport->sent_messages.size());
+  assertEquals(0, mockCanTransport->sent_messages.size());
   
   // Processing after enumeration timeout
   addMillis(101);
-  mockTransport->sent_messages.clear();
+  mockCanTransport->sent_messages.clear();
   controller.process();
 
-  assertEquals(0, mockTransport->sent_messages.size());
+  assertEquals(0, mockCanTransport->sent_messages.size());
 
   // Expect first available CANID
   assertEquals(20, controller.getModuleCANID());
@@ -274,17 +280,17 @@ void testCANID()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg = {0x11, false, false, 3, {OPC_CANID, 0x01, 0x04, 33}};
-  mockTransport->setNextMessage(msg);
+  CANMessage msg = {0x11, false, false, 4, {OPC_CANID, 0x01, 0x04, 33}};
+  mockCanTransport->setNextMessage(msg);
 
   controller.process();
 
-  assertEquals(2, mockTransport->sent_messages.size());
-  assertEquals(OPC_WRACK, mockTransport->sent_messages[0].data[0]);
-  assertEquals(OPC_GRSP, mockTransport->sent_messages[1].data[0]);
-  assertEquals(OPC_CANID, mockTransport->sent_messages[1].data[3]);
-  assertEquals(SERVICE_ID_CAN, mockTransport->sent_messages[1].data[4]);
-  assertEquals(GRSP_OK, mockTransport->sent_messages[1].data[5]);
+  assertEquals(2, mockCanTransport->sent_messages.size());
+  assertEquals(OPC_WRACK, mockCanTransport->sent_messages[0].data[0]);
+  assertEquals(OPC_GRSP, mockCanTransport->sent_messages[1].data[0]);
+  assertEquals(OPC_CANID, mockCanTransport->sent_messages[1].data[3]);
+  assertEquals(SERVICE_ID_CAN, mockCanTransport->sent_messages[1].data[4]);
+  assertEquals(GRSP_OK, mockCanTransport->sent_messages[1].data[5]);
 
   // Expect first available CANID
   assertEquals(33, controller.getModuleCANID());

--- a/test/testMinimumNodeService.cpp
+++ b/test/testMinimumNodeService.cpp
@@ -207,7 +207,7 @@ void testRequestNodeNumberElsewhere()
   VLCB::Controller controller = createController();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_RQNN, 0x02, 0x07}};
+  VLCB::CANFrame msg_rqsd = {3, {OPC_RQNN, 0x02, 0x07}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -227,7 +227,7 @@ void testSetNodeNumber()
   VLCB::Controller controller = createController();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_SNN, 0x02, 0x07}};
+  VLCB::CANFrame msg_rqsd = {3, {OPC_SNN, 0x02, 0x07}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -244,7 +244,7 @@ void testSetNodeNumberNormal()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_SNN, 0x02, 0x07}};
+  VLCB::CANFrame msg_rqsd = {3, {OPC_SNN, 0x02, 0x07}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -259,7 +259,7 @@ void testSetNodeNumberShort()
   VLCB::Controller controller = createController();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 2, {OPC_SNN, 0x02}};
+  VLCB::CANFrame msg_rqsd = {2, {OPC_SNN, 0x02}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -278,7 +278,7 @@ void testQueryNodeNumber()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 1, {OPC_QNN}};
+  VLCB::CANFrame msg_rqsd = {1, {OPC_QNN}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -298,7 +298,7 @@ void testReadNodeParametersNormalMode()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 1, {OPC_RQNP}};
+  VLCB::CANFrame msg_rqsd = {1, {OPC_RQNP}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -313,7 +313,7 @@ void testReadNodeParametersSetupMode()
   VLCB::Controller controller = createController();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 1, {OPC_RQNP}};
+  VLCB::CANFrame msg_rqsd = {1, {OPC_RQNP}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -332,7 +332,7 @@ void testReadNodeParameterCount()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_RQNPN, 0x01, 0x04, 0}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_RQNPN, 0x01, 0x04, 0}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -361,7 +361,7 @@ void testReadNodeParameterModuleId()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_RQNPN, 0x01, 0x04, 3}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_RQNPN, 0x01, 0x04, 3}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -380,7 +380,7 @@ void testReadNodeParameterInvalidIndex()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_RQNPN, 0x01, 0x04, 33}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_RQNPN, 0x01, 0x04, 33}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -402,7 +402,7 @@ void testReadNodeParameterShortMessage()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_RQNPN, 0x01, 0x04}};
+  VLCB::CANFrame msg_rqsd = {3, {OPC_RQNPN, 0x01, 0x04}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -422,7 +422,7 @@ void testModuleNameSetup()
   VLCB::Controller controller = createController();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_RQMN}};
+  VLCB::CANFrame msg_rqsd = {3, {OPC_RQMN}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -445,7 +445,7 @@ void testModuleNameLearn()
   VLCB::Controller controller = createController();
   controller.setParamFlag(PF_LRN, true); // Should really use the event teaching service here.
 
-  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_RQMN}};
+  VLCB::CANFrame msg_rqsd = {3, {OPC_RQMN}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -460,7 +460,7 @@ void testModuleNameNormal()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_RQMN}};
+  VLCB::CANFrame msg_rqsd = {3, {OPC_RQMN}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -493,7 +493,7 @@ void testServiceDiscovery()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_RQSD, 0x01, 0x04, 0}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_RQSD, 0x01, 0x04, 0}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -531,7 +531,7 @@ void testServiceDiscoveryLongMessageSvc()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_RQSD, 0x01, 0x04, 4}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_RQSD, 0x01, 0x04, 4}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -550,7 +550,7 @@ void testServiceDiscoveryIndexOutOfBand()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_RQSD, 0x01, 0x04, 7}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_RQSD, 0x01, 0x04, 7}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -569,7 +569,7 @@ void testServiceDiscoveryShortMessage()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_RQSD, 0x01, 0x04}};
+  VLCB::CANFrame msg_rqsd = {3, {OPC_RQSD, 0x01, 0x04}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -589,7 +589,7 @@ void testModeUninitializedToSetup()
   VLCB::Controller controller = createController();
   minimumNodeService->setUninitialised();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0, 0, MODE_SETUP}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_MODE, 0, 0, MODE_SETUP}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -618,7 +618,7 @@ void testModeSetupToNormal()
   minimumNodeService->setUninitialised();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0, 0, MODE_NORMAL}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_MODE, 0, 0, MODE_NORMAL}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -642,7 +642,7 @@ void testModeSetupToUnininitialized()
   minimumNodeService->setUninitialised();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0, 0, MODE_UNINITIALISED}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_MODE, 0, 0, MODE_UNINITIALISED}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -664,7 +664,7 @@ void testModeNormalToSetup()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0x01, 0x04, MODE_SETUP}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_MODE, 0x01, 0x04, MODE_SETUP}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -696,7 +696,7 @@ void testModeUninitializedToOtherThanSetup()
   VLCB::Controller controller = createController();
   minimumNodeService->setUninitialised();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0, 0, MODE_NORMAL}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_MODE, 0, 0, MODE_NORMAL}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -716,7 +716,7 @@ void testModeSetupToOtherThanNormal()
   minimumNodeService->setUninitialised();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0, 0, MODE_SETUP}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_MODE, 0, 0, MODE_SETUP}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -734,7 +734,7 @@ void testModeNormalToNormal()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0x01, 0x04, MODE_NORMAL}};
+  VLCB::CANFrame msg_rqsd = {4, {OPC_MODE, 0x01, 0x04, MODE_NORMAL}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -752,7 +752,7 @@ void testModeShortMessage()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_MODE, 0x01, 0x04}};
+  VLCB::CANFrame msg_rqsd = {3, {OPC_MODE, 0x01, 0x04}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();

--- a/test/testMinimumNodeService.cpp
+++ b/test/testMinimumNodeService.cpp
@@ -207,7 +207,7 @@ void testRequestNodeNumberElsewhere()
   VLCB::Controller controller = createController();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 3, {OPC_RQNN, 0x02, 0x07}};
+  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_RQNN, 0x02, 0x07}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -227,7 +227,7 @@ void testSetNodeNumber()
   VLCB::Controller controller = createController();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 3, {OPC_SNN, 0x02, 0x07}};
+  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_SNN, 0x02, 0x07}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -244,7 +244,7 @@ void testSetNodeNumberNormal()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 3, {OPC_SNN, 0x02, 0x07}};
+  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_SNN, 0x02, 0x07}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -259,7 +259,7 @@ void testSetNodeNumberShort()
   VLCB::Controller controller = createController();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 2, {OPC_SNN, 0x02}};
+  VLCB::CANFrame msg_rqsd = {0x11, 2, {OPC_SNN, 0x02}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -278,7 +278,7 @@ void testQueryNodeNumber()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 1, {OPC_QNN}};
+  VLCB::CANFrame msg_rqsd = {0x11, 1, {OPC_QNN}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -298,7 +298,7 @@ void testReadNodeParametersNormalMode()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 1, {OPC_RQNP}};
+  VLCB::CANFrame msg_rqsd = {0x11, 1, {OPC_RQNP}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -313,7 +313,7 @@ void testReadNodeParametersSetupMode()
   VLCB::Controller controller = createController();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 1, {OPC_RQNP}};
+  VLCB::CANFrame msg_rqsd = {0x11, 1, {OPC_RQNP}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -332,7 +332,7 @@ void testReadNodeParameterCount()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_RQNPN, 0x01, 0x04, 0}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_RQNPN, 0x01, 0x04, 0}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -361,7 +361,7 @@ void testReadNodeParameterModuleId()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_RQNPN, 0x01, 0x04, 3}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_RQNPN, 0x01, 0x04, 3}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -380,7 +380,7 @@ void testReadNodeParameterInvalidIndex()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_RQNPN, 0x01, 0x04, 33}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_RQNPN, 0x01, 0x04, 33}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -402,7 +402,7 @@ void testReadNodeParameterShortMessage()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 3, {OPC_RQNPN, 0x01, 0x04}};
+  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_RQNPN, 0x01, 0x04}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -422,7 +422,7 @@ void testModuleNameSetup()
   VLCB::Controller controller = createController();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 3, {OPC_RQMN}};
+  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_RQMN}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -445,7 +445,7 @@ void testModuleNameLearn()
   VLCB::Controller controller = createController();
   controller.setParamFlag(PF_LRN, true); // Should really use the event teaching service here.
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 3, {OPC_RQMN}};
+  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_RQMN}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -460,7 +460,7 @@ void testModuleNameNormal()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 3, {OPC_RQMN}};
+  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_RQMN}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -493,7 +493,7 @@ void testServiceDiscovery()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 0}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_RQSD, 0x01, 0x04, 0}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -531,7 +531,7 @@ void testServiceDiscoveryLongMessageSvc()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 4}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_RQSD, 0x01, 0x04, 4}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -550,7 +550,7 @@ void testServiceDiscoveryIndexOutOfBand()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 7}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_RQSD, 0x01, 0x04, 7}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -569,7 +569,7 @@ void testServiceDiscoveryShortMessage()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 3, {OPC_RQSD, 0x01, 0x04}};
+  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_RQSD, 0x01, 0x04}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -589,7 +589,7 @@ void testModeUninitializedToSetup()
   VLCB::Controller controller = createController();
   minimumNodeService->setUninitialised();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_MODE, 0, 0, MODE_SETUP}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0, 0, MODE_SETUP}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -618,7 +618,7 @@ void testModeSetupToNormal()
   minimumNodeService->setUninitialised();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_MODE, 0, 0, MODE_NORMAL}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0, 0, MODE_NORMAL}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -642,7 +642,7 @@ void testModeSetupToUnininitialized()
   minimumNodeService->setUninitialised();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_MODE, 0, 0, MODE_UNINITIALISED}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0, 0, MODE_UNINITIALISED}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -664,7 +664,7 @@ void testModeNormalToSetup()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_MODE, 0x01, 0x04, MODE_SETUP}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0x01, 0x04, MODE_SETUP}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -696,7 +696,7 @@ void testModeUninitializedToOtherThanSetup()
   VLCB::Controller controller = createController();
   minimumNodeService->setUninitialised();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_MODE, 0, 0, MODE_NORMAL}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0, 0, MODE_NORMAL}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -716,7 +716,7 @@ void testModeSetupToOtherThanNormal()
   minimumNodeService->setUninitialised();
   minimumNodeService->setSetupMode();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_MODE, 0, 0, MODE_SETUP}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0, 0, MODE_SETUP}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -734,7 +734,7 @@ void testModeNormalToNormal()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 4, {OPC_MODE, 0x01, 0x04, MODE_NORMAL}};
+  VLCB::CANFrame msg_rqsd = {0x11, 4, {OPC_MODE, 0x01, 0x04, MODE_NORMAL}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();
@@ -752,7 +752,7 @@ void testModeShortMessage()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg_rqsd = {0x11, false, false, 3, {OPC_MODE, 0x01, 0x04}};
+  VLCB::CANFrame msg_rqsd = {0x11, 3, {OPC_MODE, 0x01, 0x04}};
   mockTransport->setNextMessage(msg_rqsd);
 
   controller.process();

--- a/test/testNodeVariableService.cpp
+++ b/test/testNodeVariableService.cpp
@@ -34,7 +34,7 @@ void testNumNVs()
   VLCB::Controller controller = createController();
 
   // read parameter 6 which stores number of NVs.
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_RQNPN, 0x01, 0x04, 6}};
+  VLCB::CANFrame msg = {0x11, 4, {OPC_RQNPN, 0x01, 0x04, 6}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -53,7 +53,7 @@ void testServiceDiscovery()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 0}};
+  VLCB::CANFrame msg = {0x11, 4, {OPC_RQSD, 0x01, 0x04, 0}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -81,7 +81,7 @@ void testServiceDiscoveryNodeVarSvc()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 2}};
+  VLCB::CANFrame msg = {0x11, 4, {OPC_RQSD, 0x01, 0x04, 2}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -101,7 +101,7 @@ void testSetAndReadNV()
   VLCB::Controller controller = createController();
 
   // Set NV 3 to 42
-  VLCB::CANFrame msg = {0x11, false, false, 5, {OPC_NVSET, 0x01, 0x04, 3, 42}};
+  VLCB::CANFrame msg = {0x11, 5, {OPC_NVSET, 0x01, 0x04, 3, 42}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -113,7 +113,7 @@ void testSetAndReadNV()
   mockTransport->clearMessages();
   
   // Read NV 3
-  msg = {0x11, false, false, 4, {OPC_NVRD, 0x01, 0x04, 3}};
+  msg = {0x11, 4, {OPC_NVRD, 0x01, 0x04, 3}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -132,7 +132,7 @@ void testSetAndReadNVnew()
   VLCB::Controller controller = createController();
 
   // Set NV 3 to 17
-  VLCB::CANFrame msg = {0x11, false, false, 5, {OPC_NVSETRD, 0x01, 0x04, 3, 17}};
+  VLCB::CANFrame msg = {0x11, 5, {OPC_NVSETRD, 0x01, 0x04, 3, 17}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -151,7 +151,7 @@ void testSetNVIndexOutOfBand()
   VLCB::Controller controller = createController();
 
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, false, false, 5, {OPC_NVSET, 0x01, 0x04, 7, 42}};
+  VLCB::CANFrame msg = {0x11, 5, {OPC_NVSET, 0x01, 0x04, 7, 42}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -174,7 +174,7 @@ void testReadNVIndexOutOfBand()
   VLCB::Controller controller = createController();
 
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_NVRD, 0x01, 0x04, 7}};
+  VLCB::CANFrame msg = {0x11, 4, {OPC_NVRD, 0x01, 0x04, 7}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -201,7 +201,7 @@ void testReadNVAll()
   }
   
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_NVRD, 0x01, 0x04, 0}};
+  VLCB::CANFrame msg = {0x11, 4, {OPC_NVRD, 0x01, 0x04, 0}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -230,7 +230,7 @@ void testSetNVnewIndexOutOfBand()
   VLCB::Controller controller = createController();
 
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, false, false, 5, {OPC_NVSETRD, 0x01, 0x04, 7, 42}};
+  VLCB::CANFrame msg = {0x11, 5, {OPC_NVSETRD, 0x01, 0x04, 7, 42}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -253,7 +253,7 @@ void testSetNVShortMessage()
   VLCB::Controller controller = createController();
 
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_NVSET, 0x01, 0x04, 1}};
+  VLCB::CANFrame msg = {0x11, 4, {OPC_NVSET, 0x01, 0x04, 1}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -273,7 +273,7 @@ void testReadNVShortMessage()
   VLCB::Controller controller = createController();
 
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, false, false, 3, {OPC_NVRD, 0x01, 0x04}};
+  VLCB::CANFrame msg = {0x11, 3, {OPC_NVRD, 0x01, 0x04}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -293,7 +293,7 @@ void testSetNVnewShortMessage()
   VLCB::Controller controller = createController();
 
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_NVSETRD, 0x01, 0x04, 1}};
+  VLCB::CANFrame msg = {0x11, 4, {OPC_NVSETRD, 0x01, 0x04, 1}};
   mockTransport->setNextMessage(msg);
 
   controller.process();

--- a/test/testNodeVariableService.cpp
+++ b/test/testNodeVariableService.cpp
@@ -34,7 +34,7 @@ void testNumNVs()
   VLCB::Controller controller = createController();
 
   // read parameter 6 which stores number of NVs.
-  VLCB::CANFrame msg = {0x11, 4, {OPC_RQNPN, 0x01, 0x04, 6}};
+  VLCB::CANFrame msg = {4, {OPC_RQNPN, 0x01, 0x04, 6}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -53,7 +53,7 @@ void testServiceDiscovery()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg = {0x11, 4, {OPC_RQSD, 0x01, 0x04, 0}};
+  VLCB::CANFrame msg = {4, {OPC_RQSD, 0x01, 0x04, 0}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -81,7 +81,7 @@ void testServiceDiscoveryNodeVarSvc()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg = {0x11, 4, {OPC_RQSD, 0x01, 0x04, 2}};
+  VLCB::CANFrame msg = {4, {OPC_RQSD, 0x01, 0x04, 2}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -101,7 +101,7 @@ void testSetAndReadNV()
   VLCB::Controller controller = createController();
 
   // Set NV 3 to 42
-  VLCB::CANFrame msg = {0x11, 5, {OPC_NVSET, 0x01, 0x04, 3, 42}};
+  VLCB::CANFrame msg = {5, {OPC_NVSET, 0x01, 0x04, 3, 42}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -113,7 +113,7 @@ void testSetAndReadNV()
   mockTransport->clearMessages();
   
   // Read NV 3
-  msg = {0x11, 4, {OPC_NVRD, 0x01, 0x04, 3}};
+  msg = {4, {OPC_NVRD, 0x01, 0x04, 3}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -132,7 +132,7 @@ void testSetAndReadNVnew()
   VLCB::Controller controller = createController();
 
   // Set NV 3 to 17
-  VLCB::CANFrame msg = {0x11, 5, {OPC_NVSETRD, 0x01, 0x04, 3, 17}};
+  VLCB::CANFrame msg = {5, {OPC_NVSETRD, 0x01, 0x04, 3, 17}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -151,7 +151,7 @@ void testSetNVIndexOutOfBand()
   VLCB::Controller controller = createController();
 
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, 5, {OPC_NVSET, 0x01, 0x04, 7, 42}};
+  VLCB::CANFrame msg = {5, {OPC_NVSET, 0x01, 0x04, 7, 42}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -174,7 +174,7 @@ void testReadNVIndexOutOfBand()
   VLCB::Controller controller = createController();
 
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, 4, {OPC_NVRD, 0x01, 0x04, 7}};
+  VLCB::CANFrame msg = {4, {OPC_NVRD, 0x01, 0x04, 7}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -201,7 +201,7 @@ void testReadNVAll()
   }
   
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, 4, {OPC_NVRD, 0x01, 0x04, 0}};
+  VLCB::CANFrame msg = {4, {OPC_NVRD, 0x01, 0x04, 0}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -230,7 +230,7 @@ void testSetNVnewIndexOutOfBand()
   VLCB::Controller controller = createController();
 
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, 5, {OPC_NVSETRD, 0x01, 0x04, 7, 42}};
+  VLCB::CANFrame msg = {5, {OPC_NVSETRD, 0x01, 0x04, 7, 42}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -253,7 +253,7 @@ void testSetNVShortMessage()
   VLCB::Controller controller = createController();
 
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, 4, {OPC_NVSET, 0x01, 0x04, 1}};
+  VLCB::CANFrame msg = {4, {OPC_NVSET, 0x01, 0x04, 1}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -273,7 +273,7 @@ void testReadNVShortMessage()
   VLCB::Controller controller = createController();
 
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, 3, {OPC_NVRD, 0x01, 0x04}};
+  VLCB::CANFrame msg = {3, {OPC_NVRD, 0x01, 0x04}};
   mockTransport->setNextMessage(msg);
 
   controller.process();
@@ -293,7 +293,7 @@ void testSetNVnewShortMessage()
   VLCB::Controller controller = createController();
 
   // Set NV 7 to 42
-  VLCB::CANFrame msg = {0x11, 4, {OPC_NVSETRD, 0x01, 0x04, 1}};
+  VLCB::CANFrame msg = {4, {OPC_NVSETRD, 0x01, 0x04, 1}};
   mockTransport->setNextMessage(msg);
 
   controller.process();


### PR DESCRIPTION
Move logic for CANID enumeration from CanService to a new CanTransport which is a base class for the hardware CAN2515 class. CANFrame no longer contains the CAN fields id, ext, and rtr. CANFrame should be renamed to VlcbMessage to show that it is used Vlcb functionality. Not renamed here as this will make the changes difficult to review.