### PR TITLE
Remove FrameHandler.

### DIFF
--- a/examples/VLCB_empty/VLCB_empty.ino
+++ b/examples/VLCB_empty/VLCB_empty.ino
@@ -55,7 +55,6 @@ unsigned char mname[7] = { 'E', 'M', 'P', 'T', 'Y', ' ', ' ' };
 
 // forward function declarations
 void eventhandler(byte, VLCB::VlcbMessage *);
-void framehandler(VLCB::VlcbMessage *);
 void processSerialInput();
 void printConfig();
 
@@ -100,9 +99,6 @@ void setupVLCB()
 
   // register our VLCB event handler, to receive event messages of learned events
   ecService.setEventHandler(eventhandler);
-
-  // register our CAN frame handler, to receive *every* CAN frame
-  controller.setFrameHandler(framehandler);
 
   // set Controller LEDs to indicate the current mode
   controller.indicateMode(modconfig.currentMode);
@@ -182,25 +178,6 @@ void eventhandler(byte index, VLCB::VlcbMessage *msg)
 
   Serial << F("> event handler: index = ") << index << F(", opcode = 0x") << _HEX(msg->data[0]) << endl;
   Serial << F("> EV1 = ") << modconfig.getEventEVval(index, 1) << endl;
-}
-
-//
-/// user-defined frame processing function
-/// called from the VLCB library for *every* CAN frame received
-/// it receives a pointer to the received CAN frame
-//
-void framehandler(VLCB::VlcbMessage *msg)
-{
-  // as an example, format and display the received frame
-
-  Serial << "[" << msg->len << "] [";
-
-  for (byte d = 0; d < msg->len; d++)
-  {
-    Serial << " 0x" << _HEX(msg->data[d]);
-  }
-
-  Serial << " ]" << endl;
 }
 
 //

--- a/examples/VLCB_long_message_example/VLCB_long_message_example.ino
+++ b/examples/VLCB_long_message_example/VLCB_long_message_example.ino
@@ -57,7 +57,6 @@ unsigned char mname[7] = { 'L', 'M', 'S', 'G', 'E', 'X', ' ' };
 
 // forward function declarations
 void eventhandler(byte, VLCB::VlcbMessage *);
-void framehandler(VLCB::VlcbMessage *);
 void processSerialInput();
 void printConfig();
 void longmessagehandler(void *, const unsigned int, const byte, const byte);
@@ -106,9 +105,6 @@ void setupVLCB()
 
   // register our VLCB event handler, to receive event messages of learned events
   ecService.setEventHandler(eventhandler);
-
-  // register our CAN frame handler, to receive *every* CAN frame
-  controller.setFrameHandler(framehandler);
 
   // subscribe to long message streams and register our handler function
   lmsg.subscribe(streams, sizeof(streams) / sizeof(byte), lmsg_in, 32, longmessagehandler);
@@ -197,25 +193,6 @@ void eventhandler(byte index, VLCB::VlcbMessage *msg)
 
   Serial << F("> event handler: index = ") << index << F(", opcode = 0x") << _HEX(msg->data[0]) << endl;
   Serial << F("> EV1 = ") << modconfig.getEventEVval(index, 1) << endl;
-}
-
-//
-/// user-defined frame processing function
-/// called from the VLCB library for *every* CAN frame received
-/// it receives a pointer to the received CAN frame
-//
-void framehandler(VLCB::VlcbMessage *msg)
-{
-  // as an example, format and display the received frame
-
-  Serial << "[" << msg->len << "] [";
-
-  for (byte d = 0; d < msg->len; d++)
-  {
-    Serial << " 0x" << _HEX(msg->data[d]);
-  }
-
-  Serial << " ]" << endl;
 }
 
 //

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -68,17 +68,6 @@ void Controller::begin()
 }
 
 //
-/// register the user handler for CAN frames
-/// default args in .h declaration for opcodes array (NULL) and size (0)
-//
-void Controller::setFrameHandler(void (*fptr)(VlcbMessage *msg), byte opcodes[], byte num_opcodes)
-{
-  framehandler = fptr;
-  _opcodes = opcodes;
-  _num_opcodes = num_opcodes;
-}
-
-//
 /// assign the module parameter set
 //
 void Controller::setParams(unsigned char *mparams)
@@ -199,8 +188,6 @@ void Controller::process(byte num_messages)
       continue;
     }
 
-    callFrameHandler(&msg);
-
     for (Service * service : services)
     {
       // DEBUG_SERIAL << "> Passing raw message to " << endl;
@@ -239,38 +226,6 @@ void Controller::process(byte num_messages)
   //
   /// end of Controller message processing
   //
-}
-
-// Return true if framehandler shall be called for registered opcodes, if any.
-bool Controller::filterByOpcodes(const VlcbMessage *msg) const
-{
-  if (_num_opcodes == 0)
-  {
-    return true;
-  }
-  if (msg->len > 0)
-  {
-    unsigned int opc = msg->data[0];
-    for (byte i = 0; i < _num_opcodes; i++)
-    {
-      if (opc == _opcodes[i])
-      {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-void Controller::callFrameHandler(VlcbMessage *msg)
-{
-  if (framehandler != NULL)
-  {
-    if (filterByOpcodes(msg))
-    {
-      (void)(*framehandler)(msg);
-    }
-  }
 }
 
 void setNN(VlcbMessage *msg, unsigned int nn)

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -75,7 +75,6 @@ public:
   void setLearnMode(byte reqMode);
   bool isSetProdEventTableFlag() { return setProdEventTable; }
   void clearProdEventTableFlag();
-  void setFrameHandler(void (*fptr)(VlcbMessage *msg), byte *opcodes = NULL, byte num_opcodes = 0);
 
 private:                                          // protected members become private in derived classes
   UserInterface *_ui;
@@ -85,13 +84,8 @@ private:                                          // protected members become pr
 
   unsigned char *_mparams;
   const unsigned char *_mname;
-  void (*framehandler)(VlcbMessage *msg) = NULL;
-  byte *_opcodes = NULL;
-  byte _num_opcodes = 0;
   bool setProdEventTable = false;
 
-  bool filterByOpcodes(const VlcbMessage *msg) const;
-  void callFrameHandler(VlcbMessage *msg);
   bool sendMessageWithNNandData(int opc) { return sendMessageWithNNandData(opc, 0, 0); }
   bool sendMessageWithNNandData(int opc, int len, ...);
 };


### PR DESCRIPTION
Framehandler is only used by some example sketches to print out incoming messages. 