### PR TITLE
Major change to Event Producer to use EV1

### DIFF
--- a/docs/SerialUserInterface.md
+++ b/docs/SerialUserInterface.md
@@ -1,0 +1,34 @@
+# Serial User Interface
+This library provides a means of communicating with the module using its serial
+interface.  The functions allow the VLCB switch and LEDs to be by-passed or not
+included at all.  Additional functions that may be of use during development
+are also available.
+
+## Serial Monitor
+
+By sending a single character to the Arduino using the serial send facility in the
+serial monitor of the Arduino IDE (or similar),it is possible to initiate certain operations
+or get information from the Arduino sketch.
+
+#### 'n'
+This character will return the node configuration.
+
+#### 'e'
+This character will return the learned event table in the EEPROM.
+
+#### 'v'
+This character will return the node variables.
+
+#### 'c'
+This character will return the CAN bus status.
+
+#### 'h'
+This character will return the event hash table.
+
+#### 'm'
+This character will return the amount of free memory. 
+
+#### 'r' (implementation pending)
+This character will cause the module to renegotiate its VLCB status by requesting a node number.
+The FCU will respond as it would for any other unrecognised module.
+

--- a/docs/VLCB4in4out_README.md
+++ b/docs/VLCB4in4out_README.md
@@ -82,13 +82,16 @@ OP_CODE | HEX | Function
 
 ### Event Variables
 
+Event Variable 1 (EV1) is reserved for system use to identify the source of
+produced event.
+
 #### Consumed Events
 
 Event Variables control the action to take when a consumed event is received.
-The number of Event Variables (EV) is equal to the number of LEDs.
+The number of Event Variables (EV) is equal to the number of LEDs plus one.
 
-Event Variable 1 (EV1) controls the first LED pin in the ```LED``` array. 
-EV2 controls the second LED pin, etc.
+Event Variable 2 (EV2) controls the first LED pin in the ```LED``` array. 
+EV3 controls the second LED pin, etc.
 
 The LEDs are controlled by the LEDControl class.  This allows for any LED to be
 switched on, switched off or flashed at a rate determined in the call:
@@ -105,8 +108,22 @@ The following EV values are defined to control the LEDs in this example:
 
 #### Produced Events
 
-Event Variables, whilst present, are not used in this application.  If used in an 
-application, they may be set in the normal manner using the FCU.
+The Events Table in an Uninitiailised module is empty. When the module changes to
+Normal Mode from Uninitialised, the Events Table is populated with a default
+producer event for each of the four switches (or, in general, each producer item).
+These default events can be removed by using OPC_EVULN whist the module is in
+learn mode.
+
+A module can also be taught a short event or, indeed, a spoof event. This is
+easily done using any of the normal FCU teach techniques.  For example, a short
+event can be dragged from the Software Node and dropped onto the VLCB4in4out in
+the Node Window.  When the event variable dialgue opens, put the index number of
+the switch to be associated with the event in EV1 and press OK.  The selected
+switch will now generate that short event.
+
+If a switch default has been unlearnt and that switch not been assigned to an
+event by the FCU, operation of the switch will result in a new default event
+being generated.
 
 #### Consume Own Events
 
@@ -114,9 +131,10 @@ If the Produced Events Service and the Consume Events Service are both applied,
 the Consume Own Events Service can also be enabled.  This service provides a 
 buffer that will pass the produced event back to the Consumed Event Service.
 A consumed Own Event still only has one entry in the Event Table.  If the Event
-Variables are left as 0 or NULL, then the Consume Events Service will do nothing.
-If the Event Variables are populated as shown in the table in the Consumed Events
-Section above, the LEDs will behave accordingly to a Produced Event.
+Variables 2 onwards are left as 0 or NULL, then the Consume Events Service will
+do nothing.  Event Variable 1 will contain the value of the producer trigger 
+or switch. If the Event Variables are populated as shown in the table in the
+Consumed Events Section above, the LEDs will behave accordingly to a Produced Event.
 
 ### Node Variables
 
@@ -173,40 +191,7 @@ The FCU will show a new event produced by the Software Node in the VLCB4in4out e
 table.  It will not, for some reason, remove the now gone original event automatically.
 It is necessary to highlight the redundant event and use alt-D to remove it.
 
-## Serial Monitor
 
-By sending a single character to the Arduino using the serial send facility in the
-serial monitor of the Arduino IDE (or similar),it is possible to initiate certain operations
-or get information from the Arduino sketch.
-
-#### 'r' (implementation pending)
-This character will cause the module to renegotiate its VLCB status by requesting a node number.
-The FCU will respond as it would for any other unrecognised module.
-
-#### 'z'
-This character needs to be sent twice within 2 seconds so that its action is confirmed.
-This will reset the module and clear the EEPROM.  It should thus be used with care.
-
-Other information is available using the serial monitor using other commands:
-
-#### 'n'
-This character will return the node configuration.
-
-#### 'e'
-This character will return the learned event table in the EEPROM.
-
-#### 'v'
-This character will return the node variables.
-
-#### 'c'
-This character will return the CAN bus status.
-
-#### 'h'
-This character will return the event hash table.
-
-#### 'm'
-This character will return the amount of free memory. 
- 
  
  
  

--- a/examples/VLCB_4in4out/VLCB_4in4out.ino
+++ b/examples/VLCB_4in4out/VLCB_4in4out.ino
@@ -132,7 +132,7 @@ void setupVLCB()
   modconfig.EE_EVENTS_START = 50;
   modconfig.EE_MAX_EVENTS = 64;
   modconfig.EE_PRODUCED_EVENTS = NUM_SWITCHES;
-  modconfig.EE_NUM_EVS = NUM_LEDS;
+  modconfig.EE_NUM_EVS = 1 + NUM_LEDS;
   
 
   // initialise and load configuration
@@ -299,7 +299,7 @@ void eventhandler(byte index, VLCB::VlcbMessage *msg)
     case OPC_ASON:
     DEBUG_PRINT(F("> case is opCode ON"));
       for (byte i = 0; i < NUM_LEDS; i++) {
-        byte ev = i + 1;
+        byte ev = i + 2;
         byte evval = modconfig.getEventEVval(index, ev);
         DEBUG_PRINT(F("> EV = ") << ev << (" Value = ") << evval);
 
@@ -326,7 +326,7 @@ void eventhandler(byte index, VLCB::VlcbMessage *msg)
     case OPC_ASOF:
     DEBUG_PRINT(F("> case is opCode OFF"));
       for (byte i = 0; i < NUM_LEDS; i++) {
-        byte ev = i + 1;
+        byte ev = i + 2;
         byte evval = modconfig.getEventEVval(index, ev);
 
         if (evval > 0) {

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -214,6 +214,19 @@ byte Configuration::findEventSpace()
   return evidx;
 }
 
+byte Configuration::findExistingEventByEv(byte evindex, byte evval)
+{
+  byte i;
+  for (i = 0; i < EE_MAX_EVENTS; i++)
+  {
+    if (getEventEVval(i, evindex) == evval)
+    {
+      break;
+    }
+  }
+  return i;
+}
+
 //
 /// create a hash from a 4-byte event entry array -- NN + EN
 //

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -45,6 +45,7 @@ public:
 
   byte findExistingEvent(unsigned int nn, unsigned int en);
   byte findEventSpace();
+  byte findExistingEventByEv(byte evindex, byte evval);
 
   void printEvHashTable(bool raw);
   byte getEvTableEntry(byte tindex);

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -115,16 +115,12 @@ void Controller::setName(const unsigned char *mname)
 void Controller::indicateMode(byte mode)
 {
   // DEBUG_SERIAL << F("> indicating mode = ") << mode << endl;
-  if (_ui) {
+  if (_ui) 
+  {
     _ui->indicateMode(mode);
   }
   
   setParamFlag(PF_NORMAL, mode == MODE_NORMAL);
- 
-  if (mode == MODE_NORMAL) // used by Event Producer Service
-  {
-    setProdEventTable = true;
-  }
 }
 
 void Controller::setParamFlag(unsigned char flag, bool set)
@@ -137,11 +133,6 @@ void Controller::setParamFlag(unsigned char flag, bool set)
   {
     _mparams[PAR_FLAGS] &= ~flag;
   }
-}
-
-void Controller::clearProdEventTableFlag()
-{
-  setProdEventTable = false;
 }
 
 void Controller::indicateActivity()

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -82,8 +82,7 @@ private:                                          // protected members become pr
 
   unsigned char *_mparams;
   const unsigned char *_mname;
-  bool setProdEventTable = false;
-
+  
   bool sendMessageWithNNandData(int opc) { return sendMessageWithNNandData(opc, 0, 0); }
   bool sendMessageWithNNandData(int opc, int len, ...);
 };

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -73,9 +73,7 @@ public:
   void indicateMode(byte mode);
   void indicateActivity();
   void setLearnMode(byte reqMode);
-  bool isSetProdEventTableFlag() { return setProdEventTable; }
-  void clearProdEventTableFlag();
-
+  
 private:                                          // protected members become private in derived classes
   UserInterface *_ui;
   Configuration *module_config;

--- a/src/EventProducerService.cpp
+++ b/src/EventProducerService.cpp
@@ -198,7 +198,7 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1, byte 
     }
     
     VlcbMessage msg;
-    msg.len = 5;
+    msg.len = 8;
     msg.data[0] = opCode;
     msg.data[1] = nn_en[0];
     msg.data[2] = nn_en[1];

--- a/src/EventProducerService.cpp
+++ b/src/EventProducerService.cpp
@@ -62,20 +62,6 @@ void EventProducerService::process(UserInterface::RequestedAction requestedActio
   }
 }
 
-void EventProducerService::createDefaultProducedEvent(byte evValue)
-{
-  byte data[4];
-  byte index = module_config->findEventSpace();
-  data[0] = highByte(module_config->nodeNum);
-  data[1] = lowByte(module_config->nodeNum);
-  data[2] = 0;
-  data[3] = evValue;
-  
-  module_config->writeEvent(index, data);
-  module_config->writeEventEV(index, 1, evValue);
-  module_config->updateEvHashEntry(index);   
-}
-
 void EventProducerService::sendEvent(bool state, byte evValue)
 {
   byte nn_en[4];
@@ -110,10 +96,6 @@ void EventProducerService::sendEvent(bool state, byte evValue)
     {
       coeService->put(&msg);
     }
-  }
-  else  // Produced event doesn't exist so create a default
-  {
-    createDefaultProducedEvent(evValue);
   }
 }
 
@@ -152,10 +134,6 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1)
     {
       coeService->put(&msg);
     }
-  }
-  else  // Produced event doesn't exist so create a default
-  {
-    createDefaultProducedEvent(evValue);
   }
 }
 
@@ -196,10 +174,6 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1, byte 
       coeService->put(&msg);
     }
   }
-  else  // Produced event doesn't exist so create a default
-  {
-    createDefaultProducedEvent(evValue);
-  }
 }
 
 void EventProducerService::sendEvent(bool state, byte evValue, byte data1, byte data2, byte data3)
@@ -239,10 +213,6 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1, byte 
     {
       coeService->put(&msg);
     }
-  }
-  else  // Produced event doesn't exist so create a default
-  {
-    createDefaultProducedEvent(evValue);
   }
 }
 

--- a/src/EventProducerService.cpp
+++ b/src/EventProducerService.cpp
@@ -62,7 +62,7 @@ void EventProducerService::process(UserInterface::RequestedAction requestedActio
   }
 }
 
-void EventProducerService::createDefault(byte evValue)
+void EventProducerService::createDefaultProducedEvent(byte evValue)
 {
   byte data[4];
   byte index = module_config->findEventSpace();
@@ -113,7 +113,7 @@ void EventProducerService::sendEvent(bool state, byte evValue)
   }
   else  // Produced event doesn't exist so create a default
   {
-    createDefault(evValue);
+    createDefaultProducedEvent(evValue);
   }
 }
 
@@ -139,7 +139,7 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1)
     }
     
     VlcbMessage msg;
-    msg.len = 5;
+    msg.len = 6;
     msg.data[0] = opCode;
     msg.data[1] = nn_en[0];
     msg.data[2] = nn_en[1];
@@ -155,7 +155,7 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1)
   }
   else  // Produced event doesn't exist so create a default
   {
-    createDefault(evValue);
+    createDefaultProducedEvent(evValue);
   }
 }
 
@@ -181,7 +181,7 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1, byte 
     }
     
     VlcbMessage msg;
-    msg.len = 5;
+    msg.len = 7;
     msg.data[0] = opCode;
     msg.data[1] = nn_en[0];
     msg.data[2] = nn_en[1];
@@ -198,7 +198,7 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1, byte 
   }
   else  // Produced event doesn't exist so create a default
   {
-    createDefault(evValue);
+    createDefaultProducedEvent(evValue);
   }
 }
 
@@ -242,7 +242,7 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1, byte 
   }
   else  // Produced event doesn't exist so create a default
   {
-    createDefault(evValue);
+    createDefaultProducedEvent(evValue);
   }
 }
 

--- a/src/EventProducerService.h
+++ b/src/EventProducerService.h
@@ -33,6 +33,7 @@ public:
   void sendEvent(bool state, byte index, byte data1);
   void sendEvent(bool state, byte index, byte data1, byte data2);
   void sendEvent(bool state, byte index, byte data1, byte data2, byte data3);
+  void createDefault(byte evValue);
 
 private:
   Controller *controller;

--- a/src/EventProducerService.h
+++ b/src/EventProducerService.h
@@ -33,7 +33,6 @@ public:
   void sendEvent(bool state, byte index, byte data1);
   void sendEvent(bool state, byte index, byte data1, byte data2);
   void sendEvent(bool state, byte index, byte data1, byte data2, byte data3);
-  void createDefaultProducedEvent(byte evValue);
 
 private:
   Controller *controller;

--- a/src/EventProducerService.h
+++ b/src/EventProducerService.h
@@ -33,7 +33,7 @@ public:
   void sendEvent(bool state, byte index, byte data1);
   void sendEvent(bool state, byte index, byte data1, byte data2);
   void sendEvent(bool state, byte index, byte data1, byte data2, byte data3);
-  void createDefault(byte evValue);
+  void createDefaultProducedEvent(byte evValue);
 
 private:
   Controller *controller;

--- a/src/EventProducerService.h
+++ b/src/EventProducerService.h
@@ -41,6 +41,7 @@ private:
   void (*eventhandler)(byte index, VlcbMessage *msg);
  
   void setProducedEvents();
+  bool uninit = 0;
 };
 
 }  // VLCB


### PR DESCRIPTION
Following discussion on 5 Nov 2023 in the VLCB Team, the method of generating and using produced events has been changed.  Event Variable 1 now has a value of zero for a consumed event or the index of a producer activity for a produced event.  The system is that used by Ian Hogg in his Universal software.
This change results in a much simpler interface with the FCU that allows drag and drop teaching techniques to be used.