### PR TITLE
Fix potential problem with overwriting current command element on buffer overflow.

### DIFF
--- a/src/CircularBuffer.h
+++ b/src/CircularBuffer.h
@@ -19,8 +19,8 @@ public:
 
   bool available();
   E *peek();
-  const E * get();
-  void put(const E *entry);
+  const E & pop();
+  void put(const E &entry);
   void clear();
 
   // Diagnostic metrics access
@@ -69,10 +69,10 @@ bool CircularBuffer<E>::available()
 /// store an item to the buffer - overwrite oldest item if buffer is full
 /// never called from an interrupt context so we don't need to worry about interrupts
 template <typename E>
-void CircularBuffer<E>::put(const E * msg)
+void CircularBuffer<E>::put(const E &msg)
 {
 //  E msg;
-  buffer[head] = *msg;
+  buffer[head] = msg;
 
   if (full)
   {
@@ -93,22 +93,16 @@ void CircularBuffer<E>::put(const E * msg)
   // DEBUG_SERIAL << ">COE Puts = " << numPuts << " Size = " << size <<endl;
 }
 
-/// retrieve the next item from the buffer
+/// retrieve the next item from the buffer, requires that available() is checked first.
 template <typename E>
-const E * CircularBuffer<E>::get()
+const E & CircularBuffer<E>::pop()
 {
-  E *p = nullptr;
-
-  if (available())
-  {
-    p = &buffer[tail];
-    full = false;
-    tail = (tail + 1) % capacity;
-    ++numGets;        // Counts how many events got from buffer.
-    // DEBUG_SERIAL << ">COE Gets = " << numGets << endl;
-  }
-
-  return p;
+  uint8_t oldTail = tail;
+  full = false;
+  tail = (tail + 1) % capacity;
+  ++numGets;        // Counts how many events got from buffer.
+  // DEBUG_SERIAL << ">COE Gets = " << numGets << endl;
+  return buffer[oldTail];
 }
 
 /// peek at the next item in the buffer without removing it

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -147,7 +147,13 @@ void Controller::indicateActivity()
 void Controller::process()
 {
   //Serial << F("Ctrl::process() start, cmd queue size = ") << commandQueue.size();
-  const Command * cmd = commandQueue.available() ? commandQueue.get() : nullptr;
+  const Command * cmd = nullptr;
+  Command command;
+  if (commandQueue.available())
+  {
+    command = commandQueue.pop();
+    cmd = &command;
+  }
   //Serial << F(" cmd type = ");
   //if (cmd) Serial << cmd->commandType; else Serial << F("null");
   //Serial << endl;
@@ -167,7 +173,7 @@ void setNN(VlcbMessage *msg, unsigned int nn)
 bool Controller::sendMessage(const VlcbMessage *msg)
 {
   Command cmd = {CMD_MESSAGE_OUT, *msg};
-  commandQueue.put(&cmd);
+  commandQueue.put(cmd);
   return true;
 }
 
@@ -213,7 +219,7 @@ void Controller::sendGRSP(byte opCode, byte serviceType, byte errCode)
 void Controller::putCommand(const Command &cmd)
 {
   // Serial << F("C>put command with type=") << cmd.commandType << endl;
-  commandQueue.put(&cmd);
+  commandQueue.put(cmd);
 }
 
 void Controller::putCommand(COMMAND cmd)

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -9,7 +9,6 @@
 // Controller library
 #include <Controller.h>
 #include "MinimumNodeService.h"
-#include "CanService.h"
 #include <stdarg.h>
 
 //

--- a/test/testCircularBuffer.cpp
+++ b/test/testCircularBuffer.cpp
@@ -20,9 +20,6 @@ void testEmpty()
   assertEquals(0, buffer.getOverflows());
   assertEquals(0, buffer.getNumberOfGets());
   assertEquals(0, buffer.getNumberOfPuts());
-
-  assertEquals(nullptr, buffer.get());
-  assertEquals(0, buffer.getNumberOfGets());
 }
 
 void testHasOne()
@@ -31,7 +28,7 @@ void testHasOne()
   
   VLCB::CircularBuffer<int> buffer(4);
   int entry = 17;
-  buffer.put(&entry);
+  buffer.put(entry);
 
   assertEquals(true, buffer.available());
   assertEquals(1, buffer.getHighWaterMark());
@@ -39,7 +36,7 @@ void testHasOne()
   assertEquals(0, buffer.getNumberOfGets());
   assertEquals(1, buffer.getNumberOfPuts());
 
-  assertEquals(entry, *buffer.get());
+  assertEquals(entry, buffer.pop());
   assertEquals(1, buffer.getNumberOfGets());
   assertEquals(false, buffer.available());
 }
@@ -50,10 +47,10 @@ void testFull()
   
   VLCB::CircularBuffer<int> buffer(4);
   int entry = 1;
-  buffer.put(&entry);
-  buffer.put(&entry);
-  buffer.put(&entry);
-  buffer.put(&entry);
+  buffer.put(entry);
+  buffer.put(entry);
+  buffer.put(entry);
+  buffer.put(entry);
 
   assertEquals(true, buffer.available());
   assertEquals(4, buffer.getHighWaterMark());
@@ -68,15 +65,15 @@ void testOverflow()
   
   VLCB::CircularBuffer<int> buffer(4);
   int entry = 1;
-  buffer.put(&entry);
+  buffer.put(entry);
   entry = 2;
-  buffer.put(&entry);
+  buffer.put(entry);
   entry = 3;
-  buffer.put(&entry);
+  buffer.put(entry);
   entry = 4;
-  buffer.put(&entry);
+  buffer.put(entry);
   entry = 5;
-  buffer.put(&entry);
+  buffer.put(entry);
 
   assertEquals(true, buffer.available());
   assertEquals(4, buffer.getHighWaterMark());
@@ -85,7 +82,7 @@ void testOverflow()
   assertEquals(5, buffer.getNumberOfPuts());
   
   // First entry has been overwritten.
-  assertEquals(2, *buffer.get());
+  assertEquals(2, buffer.pop());
 }
 
 void testHeadWrapAround()
@@ -94,23 +91,23 @@ void testHeadWrapAround()
   
   VLCB::CircularBuffer<int> buffer(4);
   int entry = 1;
-  buffer.put(&entry);
+  buffer.put(entry);
   entry = 2;
-  buffer.put(&entry);
+  buffer.put(entry);
 
-  assertEquals(1, *buffer.get());
-  assertEquals(2, *buffer.get());
+  assertEquals(1, buffer.pop());
+  assertEquals(2, buffer.pop());
 
   entry = 3;
-  buffer.put(&entry);
+  buffer.put(entry);
   entry = 4;
-  buffer.put(&entry);
+  buffer.put(entry);
   entry = 5;
-  buffer.put(&entry);
+  buffer.put(entry);
 
-  assertEquals(3, *buffer.get());
-  assertEquals(4, *buffer.get());
-  assertEquals(5, *buffer.get());
+  assertEquals(3, buffer.pop());
+  assertEquals(4, buffer.pop());
+  assertEquals(5, buffer.pop());
 
   assertEquals(false, buffer.available());
   assertEquals(3, buffer.getHighWaterMark());


### PR DESCRIPTION
Fix potential problem with overwriting current command element on buffer overflow.
Make CircularBuffer API work with references instead of pointers.