### PR TITLE
Simplify mode setting

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -64,6 +64,18 @@ void Configuration::begin()
   makeEvHashTable();
 }
 
+void Configuration::setModuleUninitializedMode()
+{
+  setModuleMode(MODE_UNINITIALISED);
+  setNodeNum(0);
+}
+
+void Configuration::setModuleNormalMode(unsigned int nodeNumber)
+{
+  setModuleMode(MODE_NORMAL);
+  setNodeNum(nodeNumber);
+}
+
 void Configuration::setModuleMode(VlcbModeParams f)
 {
   currentMode = f;

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -63,7 +63,8 @@ public:
   void resetModule();
 
   void setCANID(byte canid);
-  void setModuleMode(VlcbModeParams m);
+  void setModuleUninitializedMode();
+  void setModuleNormalMode(unsigned int nodeNumber);
   void setHeartbeat(bool beat);
   void setNodeNum(unsigned int nn);
   void setEventAck(bool ea);
@@ -93,8 +94,7 @@ public:
 private:
   Storage * storage;
 
-  // Stuff below are not confirmed to be needed to be publically available.
-private:
+  void setModuleMode(VlcbModeParams m);
   byte makeHash(byte tarr[EE_HASH_BYTES]);
   void getEvArray(byte idx);
   void makeEvHashTable();

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -48,10 +48,11 @@ void MinimumNodeService::initSetup()
   // DEBUG_SERIAL << F("> requesting NN with RQNN message for NN = ") << module_config->nodeNum << endl;
 }
 
-void MinimumNodeService::setNormal()
+void MinimumNodeService::setNormal(unsigned int nn)
 {
   // DEBUG_SERIAL << F("> set Normal") << endl;
   requestingNewNN = false;
+  module_config->setNodeNum(nn);
   instantMode = MODE_NORMAL;
   module_config->setModuleMode(MODE_NORMAL);
   controller->indicateMode(MODE_NORMAL);
@@ -332,18 +333,13 @@ void MinimumNodeService::handleSetNodeNumber(const VlcbMessage *msg, unsigned in
     {
       // DEBUG_SERIAL << F("> buf[1] = ") << msg->data[1] << ", buf[2] = " << msg->data[2] << endl;
 
-      // save the NN
-      module_config->setNodeNum(nn);
+      // we are now in Normal mode - update the configuration
+      setNormal(nn);
+      // DEBUG_SERIAL << F("> current mode = ") << module_config->currentMode << F(", node number = ") << module_config->nodeNum << F(", CANID = ") << module_config->CANID << endl;
 
       // respond with NNACK
       controller->sendMessageWithNN(OPC_NNACK);
-
       // DEBUG_SERIAL << F("> sent NNACK for NN = ") << module_config->nodeNum << endl;
-
-      // we are now in Normal mode - update the configuration
-      setNormal();
-
-      // DEBUG_SERIAL << F("> current mode = ") << module_config->currentMode << F(", node number = ") << module_config->nodeNum << F(", CANID = ") << module_config->CANID << endl;
     }
   }
 }

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -52,9 +52,8 @@ void MinimumNodeService::setNormal(unsigned int nn)
 {
   // DEBUG_SERIAL << F("> set Normal") << endl;
   requestingNewNN = false;
-  module_config->setNodeNum(nn);
   instantMode = MODE_NORMAL;
-  module_config->setModuleMode(MODE_NORMAL);
+  module_config->setModuleNormalMode(nn);
   controller->indicateMode(MODE_NORMAL);
 }
 
@@ -66,8 +65,7 @@ void MinimumNodeService::setUninitialised()
   // DEBUG_SERIAL << F("> set Uninitialised") << endl;
   requestingNewNN = false;
   instantMode = MODE_UNINITIALISED;
-  module_config->setNodeNum(0);
-  module_config->setModuleMode(MODE_UNINITIALISED);
+  module_config->setModuleUninitializedMode();
   module_config->setCANID(0);
 
   controller->indicateMode(MODE_UNINITIALISED);

--- a/src/MinimumNodeService.h
+++ b/src/MinimumNodeService.h
@@ -31,7 +31,7 @@ public:
   void setHeartBeat(bool f) { noHeartbeat = !f; }
   void setSetupMode();
   void setUninitialised();
-  void setNormal();
+  void setNormal(unsigned int nn);
 
 private:
 

--- a/test/VlcbCommon.cpp
+++ b/test/VlcbCommon.cpp
@@ -46,8 +46,7 @@ VLCB::Controller createController(const std::initializer_list<VLCB::Service *> s
 
   VLCB::Controller controller(configuration.get(), services);
 
-  configuration->setModuleMode(MODE_NORMAL);
-  configuration->setNodeNum(0x0104);
+  configuration->setModuleNormalMode(0x0104);
   static std::unique_ptr<VLCB::Parameters> params;
   params.reset(new VLCB::Parameters(*configuration));
   params->setVersion(1, 1, 'a');

--- a/test/testEventProducerService.cpp
+++ b/test/testEventProducerService.cpp
@@ -200,7 +200,7 @@ void testSetProducedDefaultEventsOnNewBoard()
 
   controller.begin();
 
-  minimumNodeService->setNormal();
+  minimumNodeService->setNormal(0x0104);
 
   // Should have no events configured at start
   assertEquals(0, controller.getModuleConfig()->numEvents());
@@ -208,6 +208,13 @@ void testSetProducedDefaultEventsOnNewBoard()
   process(controller);
 
   assertEquals(1, controller.getModuleConfig()->numEvents());
+  byte eventArray[VLCB::EE_HASH_BYTES];
+  controller.getModuleConfig()->readEvent(0, eventArray);
+  assertEquals(0x01, eventArray[0]);
+  assertEquals(0x04, eventArray[1]);
+  assertEquals(0x00, eventArray[2]);
+  assertEquals(0x01, eventArray[3]);
+  assertEquals(1, controller.getModuleConfig()->getEventEVval(0, 1));
 }
 
 void testSendEventMissingInTable()


### PR DESCRIPTION
Improve test for default produced events.
Simplify mode setting so that node number is also set at the same time.