### PR TITLE
Avoid copying parameter to CAN2515::begin().

### DIFF
--- a/src/CAN2515.cpp
+++ b/src/CAN2515.cpp
@@ -34,11 +34,10 @@ CAN2515::CAN2515()
 #ifdef ARDUINO_ARCH_RP2040
 bool CAN2515::begin(bool poll, SPIClassRP2040 spi)
 #else
-bool CAN2515::begin(bool poll, SPIClass spi)
+bool CAN2515::begin(bool poll, SPIClass &spi)
 #endif
 {
   uint16_t ret;
-  bool retval = false;
 
   _numMsgsSent = 0;
   _numMsgsRcvd = 0;
@@ -86,14 +85,13 @@ bool CAN2515::begin(bool poll, SPIClass spi)
   if (ret == 0)
   {
     // DEBUG_SERIAL << F("> CAN controller initialised ok") << endl;
-    retval = true;
+    return true;
   }
   else
   {
     // DEBUG_SERIAL << F("> error initialising CAN controller, error code = ") << ret << endl;
+    return false;
   }
-
-  return retval;
 }
 
 //

--- a/src/CAN2515.h
+++ b/src/CAN2515.h
@@ -39,7 +39,7 @@ public:
 #ifdef ARDUINO_ARCH_RP2040
   bool begin(bool poll = false, SPIClassRP2040 spi = SPI);    // note default args
 #else
-  bool begin(bool poll = false, SPIClass spi = SPI);
+  bool begin(bool poll = false, SPIClass &spi = SPI);
 #endif
   bool available() override;
   CANFrame getNextCanFrame() override;


### PR DESCRIPTION
Pass SPI parameter by reference to avoid copying it on stack. 
Saves 14 bytes of program memory.