### PR TITLE
Functions for converting an int to/from two bytes.

### DIFF
--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -91,6 +91,9 @@ public:
   unsigned int freeSRAM();
   void reboot();
 
+  static void setTwoBytes(byte *target, unsigned int value);
+  static unsigned int getTwoBytes(const byte *bytes);
+
 private:
   Storage * storage;
 

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -163,12 +163,6 @@ void Controller::process()
   }
 }
 
-void setNN(VlcbMessage *msg, unsigned int nn)
-{
-  msg->data[1] = highByte(nn);
-  msg->data[2] = lowByte(nn);
-}
-
 bool Controller::sendMessage(const VlcbMessage *msg)
 {
   Action action = {ACT_MESSAGE_OUT, *msg};
@@ -183,7 +177,7 @@ bool Controller::sendMessageWithNNandData(int opc, int len, ...)
   VlcbMessage msg;
   msg.len = len + 3;
   msg.data[0] = opc;
-  setNN(&msg, module_config->nodeNum);
+  Configuration::setTwoBytes(&msg.data[1], module_config->nodeNum);
   for (int i = 0 ; i < len ; ++i)
   {
     msg.data[3 + i] = va_arg(args, int);

--- a/src/EventConsumerService.cpp
+++ b/src/EventConsumerService.cpp
@@ -70,8 +70,8 @@ void EventConsumerService::handleConsumedMessage(const VlcbMessage *msg)
 {
   //DEBUG_SERIAL << ">Handle Message " << endl;
   unsigned int opc = msg->data[0];
-  unsigned int nn = (msg->data[1] << 8) + msg->data[2];
-  unsigned int en = (msg->data[3] << 8) + msg->data[4];
+  unsigned int nn = Configuration::getTwoBytes(&msg->data[1]);
+  unsigned int en = Configuration::getTwoBytes(&msg->data[3]);
   // DEBUG_SERIAL << ">ECService handling message op=" << _HEX(opc) << " nn=" << nn << " en" << en << endl;
 
   switch (opc) 

--- a/src/EventProducerService.cpp
+++ b/src/EventProducerService.cpp
@@ -40,8 +40,7 @@ void EventProducerService::setProducedEvents()
 byte EventProducerService::createDefaultEvent(byte evValue)
 {
   byte data[4];
-  data[0] = highByte(module_config->nodeNum);
-  data[1] = lowByte(module_config->nodeNum);
+  Configuration::setTwoBytes(&data[0], module_config->nodeNum);
   data[2] = 0;
   data[3] = evValue;
   
@@ -107,8 +106,7 @@ void EventProducerService::sendEvent(bool state, byte evValue)
   if ((nn_en[0] == 0) && (nn_en[1] == 0))
   {
     opCode = (state ? OPC_ASON : OPC_ASOF);
-    nn_en[0] = highByte(module_config->nodeNum);
-    nn_en[1] = lowByte(module_config->nodeNum); 
+    Configuration::setTwoBytes(&nn_en[0], module_config->nodeNum);
   }
   else
   {
@@ -129,8 +127,7 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1)
   if ((nn_en[0] == 0) && (nn_en[1] == 0))
   {
     opCode = (state ? OPC_ASON1 : OPC_ASOF1);
-    nn_en[0] = highByte(module_config->nodeNum);
-    nn_en[1] = lowByte(module_config->nodeNum); 
+    Configuration::setTwoBytes(&nn_en[0], module_config->nodeNum);
   }
   else
   {
@@ -153,8 +150,7 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1, byte 
   if ((nn_en[0] == 0) && (nn_en[1] == 0))
   {
     opCode = (state ? OPC_ASON2 : OPC_ASOF2);
-    nn_en[0] = highByte(module_config->nodeNum);
-    nn_en[1] = lowByte(module_config->nodeNum); 
+    Configuration::setTwoBytes(&nn_en[0], module_config->nodeNum);
   }
   else
   {
@@ -177,8 +173,7 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1, byte 
   if ((nn_en[0] == 0) && (nn_en[1] == 0))
   {
     opCode = (state ? OPC_ASON3 : OPC_ASOF3);
-    nn_en[0] = highByte(module_config->nodeNum);
-    nn_en[1] = lowByte(module_config->nodeNum); 
+    Configuration::setTwoBytes(&nn_en[0], module_config->nodeNum);
   }
   else
   {
@@ -196,7 +191,7 @@ void EventProducerService::sendEvent(bool state, byte evValue, byte data1, byte 
 void EventProducerService::handleProdSvcMessage(const VlcbMessage *msg) 
 {
   unsigned int opc = msg->data[0];
-  unsigned int nn = (msg->data[1] << 8) + msg->data[2];
+  unsigned int nn = Configuration::getTwoBytes(&msg->data[1]);
   // DEBUG_SERIAL << ">VLCBProdSvc handling message op=" << _HEX(opc) << " nn=" << nn << " en" << en << endl;
 
   switch (opc) 

--- a/src/EventTeachingService.cpp
+++ b/src/EventTeachingService.cpp
@@ -42,8 +42,8 @@ void EventTeachingService::process(const Action *action)
 void EventTeachingService::handleMessage(const VlcbMessage *msg) 
 {
   unsigned int opc = msg->data[0];
-  unsigned int nn = (msg->data[1] << 8) + msg->data[2];
-  unsigned int en = (msg->data[3] << 8) + msg->data[4];
+  unsigned int nn = Configuration::getTwoBytes(&msg->data[1]);
+  unsigned int en = Configuration::getTwoBytes(&msg->data[3]);
   //DEBUG_SERIAL << "ets>VlcbSvc handling message op=" << _HEX(opc) << " nn=" << nn << " en" << en << endl;
 
   switch (opc)

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -162,7 +162,7 @@ void MinimumNodeService::process(const Action *action)
 void MinimumNodeService::handleMessage(const VlcbMessage *msg)
 {
   unsigned int opc = msg->data[0];
-  unsigned int nn = (msg->data[1] << 8) + msg->data[2];
+  unsigned int nn = Configuration::getTwoBytes(&msg->data[1]);
 
   switch (opc)
   {

--- a/src/NodeVariableService.cpp
+++ b/src/NodeVariableService.cpp
@@ -28,7 +28,7 @@ void NodeVariableService::process(const Action *action)
 void NodeVariableService::handleMessage(const VlcbMessage *msg)
 {
   unsigned int opc = msg->data[0];
-  unsigned int nn = (msg->data[1] << 8) + msg->data[2];
+  unsigned int nn = Configuration::getTwoBytes(&msg->data[1]);
 
   switch (opc)
   {


### PR DESCRIPTION
Simplifies code that is getting or setting two bytes from/to a given value.
I did this change to see if I could reduce program memory because of the code duplication. But unfortunately it doesn't save anything. But it is still useful as I think the code is easier to read.