### PR TITLE
Avoid copying data through CanFrame

### DIFF
--- a/src/CAN2515.cpp
+++ b/src/CAN2515.cpp
@@ -110,7 +110,7 @@ bool CAN2515::available()
 /// get next unprocessed message from the buffer
 /// must call available first to ensure there is something to get
 //
-CANFrame CAN2515::getNextCanFrame()
+void CAN2515::getNextCanFrame(CreateCanFrameCallback *callback)
 {
   // DEBUG_SERIAL << F("CAN2515 trying to get next message.") << endl;
   CANMessage message;       // ACAN2515 frame class
@@ -123,15 +123,8 @@ CANFrame CAN2515::getNextCanFrame()
 //  DEBUG_SERIAL << endl;
 
   ++_numMsgsRcvd;
-  
-  CANFrame frame;
-  frame.id = message.id;
-  frame.ext = message.ext;
-  frame.rtr = message.rtr;
-  frame.len = message.len;
-  memcpy(frame.data, message.data, message.len);
 
-  return frame;
+  callback->handleIncomingCanFrame(message.id, message.rtr, message.ext, message.len, message.data);
 }
 
 //

--- a/src/CAN2515.cpp
+++ b/src/CAN2515.cpp
@@ -137,21 +137,28 @@ CANFrame CAN2515::getNextCanFrame()
 //
 /// send a VLCB message
 //
-bool CAN2515::sendCanFrame(CANFrame *frame)
+bool CAN2515::sendCanFrame(uint32_t id, bool rtr, bool ext, const VlcbMessage *message)
 {
-  CANMessage msg;
-  msg.id = frame->id;
-  msg.ext = frame->ext;
-  msg.rtr = frame->rtr;
-  msg.len = frame->len;
-  memcpy(msg.data, frame->data, frame->len);
+  CANMessage canMsg;
+  canMsg.id = id;
+  canMsg.ext = ext;
+  canMsg.rtr = rtr;
+  if (message == nullptr)
+  {
+    canMsg.len = 0;
+  }
+  else
+  {
+    canMsg.len = message->len;
+    memcpy(canMsg.data, message->data, message->len);
+  }
 
 //  DEBUG_SERIAL << F("CAN2515 sendCanFrame id=") << (msg->id & 0x7F) << " len=" << msg->len << " rtr=" << rtr;
 //  if (msg->len > 0)
 //    DEBUG_SERIAL << " op=" << _HEX(msg->data[0]);
 //  DEBUG_SERIAL << endl;
 
-  bool ret = canp->tryToSend(msg);
+  bool ret = canp->tryToSend(canMsg);
   _numMsgsSent += ret;
 
   // Simple workaround for sending many messages. Let the underlying hardware some time to send this message before next.

--- a/src/CAN2515.h
+++ b/src/CAN2515.h
@@ -43,7 +43,7 @@ public:
 #endif
   bool available() override;
   CANFrame getNextCanFrame() override;
-  bool sendCanFrame(CANFrame *frame) override;
+  bool sendCanFrame(uint32_t id, bool rtr, bool ext, const VlcbMessage *message) override;
   void reset() override;
 
   // these methods are specific to this implementation

--- a/src/CAN2515.h
+++ b/src/CAN2515.h
@@ -42,7 +42,7 @@ public:
   bool begin(bool poll = false, SPIClass & spi = SPI);
 #endif
   bool available() override;
-  CANFrame getNextCanFrame() override;
+  void getNextCanFrame(CreateCanFrameCallback *callback) override;
   bool sendCanFrame(uint32_t id, bool rtr, bool ext, const VlcbMessage *message) override;
   void reset() override;
 

--- a/src/CanService.cpp
+++ b/src/CanService.cpp
@@ -214,15 +214,9 @@ bool CanService::sendMessage(const VlcbMessage *msg)
   // rtr and ext default to false unless arguments are supplied - see method definition in .h
   // priority defaults to 1011 low/medium
 
-  CANFrame frame;
-  frame.id = makeHeader_impl(controller->getModuleCANID(), DEFAULT_PRIORITY);
-  frame.len = msg->len;
-  frame.rtr = false;
-  frame.ext = false;
-  memcpy(frame.data, msg->data, msg->len);
-
   controller->indicateActivity();
-  return sendCanFrame(&frame);
+  uint32_t id = makeHeader_impl(controller->getModuleCANID(), DEFAULT_PRIORITY);
+  return sendCanFrame(id, false, false, msg);
 }
 
 bool CanService::sendRtrFrame()
@@ -232,13 +226,8 @@ bool CanService::sendRtrFrame()
 
 bool CanService::sendEmptyFrame(bool rtr)
 {
-  CANFrame frame;
-  frame.id = makeHeader_impl(controller->getModuleCANID(), DEFAULT_PRIORITY);
-  frame.rtr = rtr;
-  frame.ext = false;
-  frame.len = 0;
-
-  return sendCanFrame(&frame);
+  uint32_t id = makeHeader_impl(controller->getModuleCANID(), DEFAULT_PRIORITY);
+  return sendCanFrame(id, rtr, false, nullptr);
 }
 
 void CanService::checkCANenumTimout()

--- a/src/CanService.h
+++ b/src/CanService.h
@@ -40,7 +40,8 @@ private:
   bool sendMessage(const VlcbMessage *msg);
   bool sendRtrFrame();
   bool sendEmptyFrame(bool rtr = false);
-  bool sendCanFrame(CANFrame *msg) { return canTransport->sendCanFrame(msg); }
+  bool sendCanFrame(uint32_t id, bool rtr, bool ext, const VlcbMessage *msg)
+    { return canTransport->sendCanFrame(id, rtr, ext, msg); }
   void startCANenumeration(bool fromENUM = false);
 
   void checkIncomingCanFrame();

--- a/src/CanService.h
+++ b/src/CanService.h
@@ -15,7 +15,7 @@ namespace VLCB
 class Configuration;
 struct VlcbMessage;
 
-class CanService : public Service
+class CanService : public Service, public CreateCanFrameCallback
 {
 
 public:
@@ -47,6 +47,9 @@ private:
   void checkIncomingCanFrame();
   void checkCANenumTimout();
   byte findFreeCanId();
+
+  // Implement interface CreateCanFrameCallback
+  void handleIncomingCanFrame(uint32_t id, bool rtr, bool ext, uint8_t len, uint8_t *data) override;
 
   bool enumeration_required = false;
   bool bCANenum = false;

--- a/src/CanTransport.h
+++ b/src/CanTransport.h
@@ -11,6 +11,8 @@
 namespace VLCB
 {
 
+struct VlcbMessage;
+
 struct CANFrame
 {
   uint32_t id;
@@ -26,7 +28,7 @@ class CanTransport : public Transport
 public:
   virtual bool available() = 0;
   virtual CANFrame getNextCanFrame() = 0;
-  virtual bool sendCanFrame(CANFrame *msg) = 0;
+  virtual bool sendCanFrame(uint32_t id, bool rtr, bool ext, const VlcbMessage *msg) = 0;
 };
 
 }

--- a/src/CanTransport.h
+++ b/src/CanTransport.h
@@ -22,12 +22,17 @@ struct CANFrame
   uint8_t data[8];
 };
 
+struct CreateCanFrameCallback
+{
+  virtual void handleIncomingCanFrame(uint32_t id, bool rtr, bool ext, uint8_t len, uint8_t data[8]) = 0;
+};
+
 // Interface for CAN transports 
 class CanTransport : public Transport
 {
 public:
   virtual bool available() = 0;
-  virtual CANFrame getNextCanFrame() = 0;
+  virtual void getNextCanFrame(CreateCanFrameCallback *callback) = 0;
   virtual bool sendCanFrame(uint32_t id, bool rtr, bool ext, const VlcbMessage *msg) = 0;
 };
 

--- a/src/SerialGC.cpp
+++ b/src/SerialGC.cpp
@@ -95,10 +95,23 @@ namespace VLCB
   /// send a CANMessage message in GridConnect format
   // see Gridconnect format at beginning of file for byte positions
   //
-  bool SerialGC::sendCanFrame(CANFrame *frame)
+  bool SerialGC::sendCanFrame(uint32_t id, bool rtr, bool ext, const VlcbMessage *msg)
   {
     transmitCount++;
-    bool result = encodeGridConnect(txBuffer, frame);
+    CANFrame frame;
+    frame.id = id;
+    frame.rtr = rtr;
+    frame.ext = ext;
+    if (msg == nullptr)
+    {
+      frame.len = 0;
+    }
+    else
+    {
+      frame.len = msg->len;
+      memcpy(frame.data, msg->data, msg->len);
+    }
+    bool result = encodeGridConnect(txBuffer, &frame);
     if (result)
     {
       // output the message

--- a/src/SerialGC.cpp
+++ b/src/SerialGC.cpp
@@ -85,9 +85,9 @@ namespace VLCB
   /// get the available CANMessage
   /// must call available first to ensure there is something to get
   //
-  CANFrame SerialGC::getNextCanFrame()
+  void SerialGC::getNextCanFrame(CreateCanFrameCallback *callback)
   {
-    return rxCANFrame;
+    callback->handleIncomingCanFrame(rxCANFrame.id, rxCANFrame.rtr, rxCANFrame.ext, rxCANFrame.len, rxCANFrame.data);
   }
 
 

--- a/src/SerialGC.h
+++ b/src/SerialGC.h
@@ -31,7 +31,7 @@ namespace VLCB
     bool begin();
 
     bool available() override;
-    CANFrame getNextCanFrame() override;
+    void getNextCanFrame(CreateCanFrameCallback *callback) override;
     bool sendCanFrame(uint32_t id, bool rtr, bool ext, const VlcbMessage *msg) override;
     void reset() override;
 

--- a/src/SerialGC.h
+++ b/src/SerialGC.h
@@ -32,7 +32,7 @@ namespace VLCB
 
     bool available() override;
     CANFrame getNextCanFrame() override;
-    bool sendCanFrame(CANFrame *frame) override;
+    bool sendCanFrame(uint32_t id, bool rtr, bool ext, const VlcbMessage *msg) override;
     void reset() override;
 
     unsigned int receiveCounter() override { return receivedCount; }

--- a/test/MockCanTransport.cpp
+++ b/test/MockCanTransport.cpp
@@ -19,9 +19,22 @@ VLCB::CANFrame MockCanTransport::getNextCanFrame()
   return msg;
 }
 
-bool MockCanTransport::sendCanFrame(VLCB::CANFrame *frame)
+bool MockCanTransport::sendCanFrame(uint32_t id, bool rtr, bool ext, const VLCB::VlcbMessage *msg)
 {
-  sent_frames.push_back(*frame);
+  VLCB::CANFrame frame;
+  frame.id = id;
+  frame.rtr = rtr;
+  frame.ext = ext;
+  if (msg == nullptr)
+  {
+    frame.len = 0;
+  }
+  else
+  {
+    frame.len = msg->len;
+    memcpy(frame.data, msg->data, msg->len);
+  }
+  sent_frames.push_back(frame);
   return true;
 }
 

--- a/test/MockCanTransport.cpp
+++ b/test/MockCanTransport.cpp
@@ -12,11 +12,11 @@ bool MockCanTransport::available()
   return !incoming_frames.empty();
 }
 
-VLCB::CANFrame MockCanTransport::getNextCanFrame()
+void MockCanTransport::getNextCanFrame(VLCB::CreateCanFrameCallback *callback)
 {
   VLCB::CANFrame msg = incoming_frames.front();
   incoming_frames.pop_front();
-  return msg;
+  callback->handleIncomingCanFrame(msg.id, msg.rtr, msg.ext, msg.len, msg.data);
 }
 
 bool MockCanTransport::sendCanFrame(uint32_t id, bool rtr, bool ext, const VLCB::VlcbMessage *msg)

--- a/test/MockCanTransport.h
+++ b/test/MockCanTransport.h
@@ -19,7 +19,7 @@ class MockCanTransport : public VLCB::CanTransport
 public:
   virtual bool available() override;
   virtual VLCB::CANFrame getNextCanFrame() override;
-  virtual bool sendCanFrame(VLCB::CANFrame *frame) override;
+  virtual bool sendCanFrame(uint32_t id, bool rtr, bool ext, const VLCB::VlcbMessage *msg) override;
   
   virtual void reset() override;
 

--- a/test/MockCanTransport.h
+++ b/test/MockCanTransport.h
@@ -18,7 +18,7 @@ class MockCanTransport : public VLCB::CanTransport
 {
 public:
   virtual bool available() override;
-  virtual VLCB::CANFrame getNextCanFrame() override;
+  virtual void getNextCanFrame(VLCB::CreateCanFrameCallback *callback) override;
   virtual bool sendCanFrame(uint32_t id, bool rtr, bool ext, const VLCB::VlcbMessage *msg) override;
   
   virtual void reset() override;


### PR DESCRIPTION
Refactoring how a VlcbMessage is sent to/received from the CAN2515 driver.
Instead of creating a CanFrame object for the CAN2515 driver, pass the CAN data as parameters to the send method. 
Receiving data is done through a callback that passes the CAN data to CanService.
Start reviewing these changes by looking at CanTransport.h.

The code is harder to read but saves about 120 bytes of program memory. Is this memory saving worth the more complicated code?