### PR TITLE
Prevent compiling for DUE case

### DIFF
--- a/src/EepromInternalStorage.cpp
+++ b/src/EepromInternalStorage.cpp
@@ -5,7 +5,9 @@
 
 #include "EepromInternalStorage.h"
 
+#ifndef __SAM3X8E__
 #include <EEPROM.h>
+#endif
 
 namespace VLCB
 {
@@ -51,7 +53,9 @@ byte EepromInternalStorage::readBytes(unsigned int eeaddress, byte nbytes, byte 
 
 byte EepromInternalStorage::getChipEEPROMVal(unsigned int eeaddress)
 {
+#ifndef __SAM3X8E__
   return EEPROM.read(eeaddress);
+#endif
 }
 
 
@@ -83,7 +87,9 @@ void EepromInternalStorage::writeBytes(unsigned int eeaddress, const byte src[],
 //
 void EepromInternalStorage::setChipEEPROMVal(unsigned int eeaddress, byte val)
 {
+#ifndef __SAM3X8E__
   EEPROM.write(eeaddress, val);
+#endif
 
 #if defined ESP32 || defined ESP8266 || defined ARDUINO_ARCH_RP2040
   EEPROM.commit();

--- a/src/EepromInternalStorage.h
+++ b/src/EepromInternalStorage.h
@@ -16,7 +16,7 @@ public:
 
 #ifdef __SAM3X8E__
 // If SAM3X8E is defined then this file shall be compilable but this class shall not be instantiatable and will not compile if used anyway.
-  DueEepromEmulationStorage() = delete;
+  EepromInternalStorage() = delete;
 #endif
 
   virtual void begin() override;

--- a/src/EepromInternalStorage.h
+++ b/src/EepromInternalStorage.h
@@ -13,6 +13,12 @@ namespace VLCB
 class EepromInternalStorage : public Storage
 {
 public:
+
+#ifdef __SAM3X8E__
+// If SAM3X8E is defined then this file shall be compilable but this class shall not be instantiatable and will not compile if used anyway.
+  DueEepromEmulationStorage() = delete;
+#endif
+
   virtual void begin() override;
 
   virtual byte read(unsigned int eeaddress) override;


### PR DESCRIPTION
Discussed with Sven. This means that the DUE case will not fail as it does not have a file EEPROM.h