### PR TITLE
Minor changes to suppress warnings

### DIFF
--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -147,6 +147,10 @@ void MinimumNodeService::process(const Action *action)
       
       case ACT_MESSAGE_IN:
         handleMessage(&action->vlcbMessage);
+		break;
+
+      default:
+          break;
 
     }
   }

--- a/src/Service.h
+++ b/src/Service.h
@@ -16,7 +16,7 @@ struct Action;
 class Service
 {
 public:
-  virtual void setController(Controller *controller) {}
+  virtual void setController(Controller * /*controller*/) {}
   virtual void begin() {}
   virtual byte getServiceID() = 0;
   virtual byte getServiceVersionID() = 0;


### PR DESCRIPTION
I have made two changes. One suppresses an unused parameter warning in service.h. The other one provides a default case for the outer switch statement in MinimumNodeService.cpp in function process().