### PR TITLE
Template CANFrame

### DIFF
--- a/Arduino/Streaming.h
+++ b/Arduino/Streaming.h
@@ -8,6 +8,7 @@ struct Serial_T
   char read();
   void flush();
   unsigned char readBytesUntil(int termChar, char *string, int length);
+  void print(const char *);
   void println(const char *);
 };
 extern struct Serial_T Serial;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ add_library(core_library OBJECT
         src/LongMessageService.h
         src/MinimumNodeService.cpp
         src/MinimumNodeService.h
-        src/CanService.cpp
+#        src/CanService.cpp
         src/CanService.h
         src/EventConsumerService.cpp
         src/EventConsumerService.h

--- a/examples/VLCB_1in1out/VLCB_1in1out.ino
+++ b/examples/VLCB_1in1out/VLCB_1in1out.ino
@@ -48,7 +48,7 @@ VLCB::CAN2515 can2515;                  // CAN transport object
 VLCB::LEDUserInterface ledUserInterface(LED_GRN, LED_YLW, SWITCH0);
 VLCB::SerialUserInterface serialUserInterface(&can2515);
 VLCB::MinimumNodeService mnService;
-VLCB::CanService canService(&can2515);
+VLCB::CanService<CANMessage> canService(&can2515);
 VLCB::NodeVariableService nvService;
 VLCB::ConsumeOwnEventsService coeService;
 VLCB::EventConsumerService ecService;

--- a/src/CAN2515.cpp
+++ b/src/CAN2515.cpp
@@ -113,9 +113,9 @@ bool CAN2515::available()
 CANFrame<CANMessage> CAN2515::getNextCanFrame()
 {
   // DEBUG_SERIAL << F("CAN2515 trying to get next message.") << endl;
-  CANMessage message;       // ACAN2515 frame class
 
-  canp->receive(message);
+  CANFrame<CANMessage> frame;       // contains a ACAN2515 frame class
+  canp->receive(frame.getMessage());
 
 //  DEBUG_SERIAL << F("CAN2515 getNextCanFrame id=") << (msg.id & 0x7F) << " len=" << msg.len << " rtr=" << msg.rtr;
 //  if (msg.len > 0)
@@ -123,13 +123,6 @@ CANFrame<CANMessage> CAN2515::getNextCanFrame()
 //  DEBUG_SERIAL << endl;
 
   ++_numMsgsRcvd;
-  
-  CANFrame<CANMessage> frame;
-  frame.id = message.id;
-  frame.ext = message.ext;
-  frame.rtr = message.rtr;
-  frame.len = message.len;
-  memcpy(frame.data, message.data, message.len);
 
   return frame;
 }
@@ -139,19 +132,12 @@ CANFrame<CANMessage> CAN2515::getNextCanFrame()
 //
 bool CAN2515::sendCanFrame(CANFrame<CANMessage> *frame)
 {
-  CANMessage msg;
-  msg.id = frame->id;
-  msg.ext = frame->ext;
-  msg.rtr = frame->rtr;
-  msg.len = frame->len;
-  memcpy(msg.data, frame->data, frame->len);
-
 //  DEBUG_SERIAL << F("CAN2515 sendCanFrame id=") << (msg->id & 0x7F) << " len=" << msg->len << " rtr=" << rtr;
 //  if (msg->len > 0)
 //    DEBUG_SERIAL << " op=" << _HEX(msg->data[0]);
 //  DEBUG_SERIAL << endl;
 
-  bool ret = canp->tryToSend(msg);
+  bool ret = canp->tryToSend(frame->getMessage());
   _numMsgsSent += ret;
 
   // Simple workaround for sending many messages. Let the underlying hardware some time to send this message before next.

--- a/src/CAN2515.cpp
+++ b/src/CAN2515.cpp
@@ -110,7 +110,7 @@ bool CAN2515::available()
 /// get next unprocessed message from the buffer
 /// must call available first to ensure there is something to get
 //
-CANFrame CAN2515::getNextCanFrame()
+CANFrame<CANMessage> CAN2515::getNextCanFrame()
 {
   // DEBUG_SERIAL << F("CAN2515 trying to get next message.") << endl;
   CANMessage message;       // ACAN2515 frame class
@@ -124,7 +124,7 @@ CANFrame CAN2515::getNextCanFrame()
 
   ++_numMsgsRcvd;
   
-  CANFrame frame;
+  CANFrame<CANMessage> frame;
   frame.id = message.id;
   frame.ext = message.ext;
   frame.rtr = message.rtr;
@@ -137,7 +137,7 @@ CANFrame CAN2515::getNextCanFrame()
 //
 /// send a VLCB message
 //
-bool CAN2515::sendCanFrame(CANFrame *frame)
+bool CAN2515::sendCanFrame(CANFrame<CANMessage> *frame)
 {
   CANMessage msg;
   msg.id = frame->id;

--- a/src/CAN2515.h
+++ b/src/CAN2515.h
@@ -29,7 +29,17 @@ static const uint32_t OSCFREQ = 16000000UL;                 // crystal frequency
 /// to support the MCP2515/25625 CAN controllers
 //
 
-class CAN2515 : public CanTransport
+template <>
+struct CANFrame<CANMessage>
+{
+  uint32_t id;
+  bool ext;
+  bool rtr;
+  uint8_t len;
+  uint8_t data[8];
+};
+
+class CAN2515 : public CanTransport<CANMessage>
 {
 public:
 
@@ -42,8 +52,8 @@ public:
   bool begin(bool poll = false, SPIClass & spi = SPI);
 #endif
   bool available() override;
-  CANFrame getNextCanFrame() override;
-  bool sendCanFrame(CANFrame *frame) override;
+  CANFrame<CANMessage> getNextCanFrame() override;
+  bool sendCanFrame(CANFrame<CANMessage> *frame) override;
   void reset() override;
 
   // these methods are specific to this implementation

--- a/src/CAN2515.h
+++ b/src/CAN2515.h
@@ -32,11 +32,22 @@ static const uint32_t OSCFREQ = 16000000UL;                 // crystal frequency
 template <>
 struct CANFrame<CANMessage>
 {
-  uint32_t id;
-  bool ext;
-  bool rtr;
-  uint8_t len;
-  uint8_t data[8];
+  CANMessage &getMessage() { return msg; }
+
+  uint32_t id() const { return msg.id; }
+  bool ext() const { return msg.ext; }
+  bool rtr() const { return msg.rtr; }
+  uint8_t len() const { return msg.len; }
+  const void *data() const { return msg.data; }
+
+  void id(uint32_t id) { msg.id = id; }
+  void ext(bool ext) { msg.ext = ext; }
+  void rtr(bool rtr) { msg.rtr = rtr; }
+  void len(byte len) { msg.len = len; }
+  byte *data() { return msg.data; }
+
+private:
+  CANMessage msg;
 };
 
 class CAN2515 : public CanTransport<CANMessage>

--- a/src/CanService.cpp
+++ b/src/CanService.cpp
@@ -160,13 +160,13 @@ void CanService<T>::checkIncomingCanFrame()
   CANFrame<T> canFrame = canTransport->getNextCanFrame();
 
   // is this an extended frame ? we currently ignore these as bootloader, etc data may confuse us !
-  if (canFrame.ext)
+  if (canFrame.ext())
   {
     return;
   }
 
   // is this a CANID enumeration request from another node (RTR set) ?
-  if (canFrame.rtr)
+  if (canFrame.rtr())
   {
     // DEBUG_SERIAL << F("> CANID enumeration RTR from CANID = ") << remoteCANID << endl;
     // send an empty canFrame to show our CANID
@@ -178,18 +178,18 @@ void CanService<T>::checkIncomingCanFrame()
 
   controller->indicateActivity();
 
-  byte remoteCANID = getCANID(canFrame.id);
+  byte remoteCANID = getCANID(canFrame.id());
 
   /// set flag if we find a CANID conflict with the frame's producer
   /// doesn't apply to RTR or zero-length frames, so as not to trigger an enumeration loop
-  if (remoteCANID == controller->getModuleCANID() && canFrame.len > 0)
+  if (remoteCANID == controller->getModuleCANID() && canFrame.len() > 0)
   {
     // DEBUG_SERIAL << F("> CAN id clash, enumeration required") << endl;
     enumeration_required = true;
   }
 
   // are we enumerating CANIDs ?
-  if (bCANenum && canFrame.len == 0)
+  if (bCANenum && canFrame.len() == 0)
   {
     // store this response in the responses array
     if (remoteCANID > 0)
@@ -203,8 +203,8 @@ void CanService<T>::checkIncomingCanFrame()
   }
 
   // The incoming CAN frame is a VLCB message.
-  Action action = {ACT_MESSAGE_IN, {canFrame.len}};
-  memcpy(action.vlcbMessage.data, canFrame.data, canFrame.len);
+  Action action = {ACT_MESSAGE_IN, {canFrame.len()}};
+  memcpy(action.vlcbMessage.data, canFrame.data(), canFrame.len());
 
   controller->putAction(action);
 }
@@ -227,11 +227,11 @@ bool CanService<T>::sendMessage(const VlcbMessage *msg)
   // priority defaults to 1011 low/medium
 
   CANFrame<T> frame;
-  frame.id = makeHeader_impl(controller->getModuleCANID(), DEFAULT_PRIORITY);
-  frame.len = msg->len;
-  frame.rtr = false;
-  frame.ext = false;
-  memcpy(frame.data, msg->data, msg->len);
+  frame.id(makeHeader_impl(controller->getModuleCANID(), DEFAULT_PRIORITY));
+  frame.len(msg->len);
+  frame.rtr(false);
+  frame.ext(false);
+  memcpy(frame.data(), msg->data, msg->len);
 
   controller->indicateActivity();
   return sendCanFrame(&frame);
@@ -247,10 +247,10 @@ template <typename T>
 bool CanService<T>::sendEmptyFrame(bool rtr)
 {
   CANFrame<T> frame;
-  frame.id = makeHeader_impl(controller->getModuleCANID(), DEFAULT_PRIORITY);
-  frame.rtr = rtr;
-  frame.ext = false;
-  frame.len = 0;
+  frame.id(makeHeader_impl(controller->getModuleCANID(), DEFAULT_PRIORITY));
+  frame.rtr(rtr);
+  frame.ext(false);
+  frame.len(0);
 
   return sendCanFrame(&frame);
 }

--- a/src/CanService.h
+++ b/src/CanService.h
@@ -15,11 +15,12 @@ namespace VLCB
 class Configuration;
 struct VlcbMessage;
 
+template<typename T>
 class CanService : public Service
 {
 
 public:
-  CanService(CanTransport * tpt) : canTransport(tpt) {}
+  CanService(CanTransport<T> * tpt) : canTransport(tpt) {}
 
   virtual void setController(Controller *cntrl) override;
   virtual byte getServiceID() override { return SERVICE_ID_CAN; }
@@ -31,7 +32,7 @@ private:
 
   Controller *controller;
   Configuration * module_config;  // Shortcut to reduce indirection code.
-  CanTransport * canTransport;
+  CanTransport<T> * canTransport;
 
   void handleCanServiceMessage(const VlcbMessage *msg);
   void handleEnumeration(unsigned int nn);
@@ -40,7 +41,7 @@ private:
   bool sendMessage(const VlcbMessage *msg);
   bool sendRtrFrame();
   bool sendEmptyFrame(bool rtr = false);
-  bool sendCanFrame(CANFrame *msg) { return canTransport->sendCanFrame(msg); }
+  bool sendCanFrame(CANFrame<T> *msg) { return canTransport->sendCanFrame(msg); }
   void startCANenumeration(bool fromENUM = false);
 
   void checkIncomingCanFrame();
@@ -55,3 +56,5 @@ private:
 };
 
 }
+
+#include "CanService.cpp"

--- a/src/CanTransport.h
+++ b/src/CanTransport.h
@@ -11,22 +11,19 @@
 namespace VLCB
 {
 
+template <typename T>
 struct CANFrame
 {
-  uint32_t id;
-  bool ext;
-  bool rtr;
-  uint8_t len;
-  uint8_t data[8];
 };
 
 // Interface for CAN transports 
+template <typename T>
 class CanTransport : public Transport
 {
 public:
   virtual bool available() = 0;
-  virtual CANFrame getNextCanFrame() = 0;
-  virtual bool sendCanFrame(CANFrame *msg) = 0;
+  virtual CANFrame<T> getNextCanFrame() = 0;
+  virtual bool sendCanFrame(CANFrame<T> *msg) = 0;
 };
 
 }

--- a/src/GridConnect.cpp
+++ b/src/GridConnect.cpp
@@ -52,7 +52,7 @@
 namespace VLCB
 {
 
-  bool encodeGridConnect(char * gcBuffer, CANFrame *frame)
+  bool encodeGridConnect(char * gcBuffer, CANFrame<GCFrame> *frame)
   {
       byte offset = 0;
       gcBuffer[0] = 0;  // null terminate buffer to start with
@@ -146,7 +146,7 @@ namespace VLCB
   // convert a gridconnect message to CANFrame object
   // see Gridconnect format at beginning of file for byte positions
   //
-  bool decodeGridConnect(const char * gcBuffer, CANFrame *frame) 
+  bool decodeGridConnect(const char * gcBuffer, CANFrame<GCFrame> *frame) 
   {
     int gcIndex = 0;                          // index used to 'walk' gc frame
     int gcBufferLength = strlen(gcBuffer);    // save for later use

--- a/src/GridConnect.h
+++ b/src/GridConnect.h
@@ -8,6 +8,19 @@
 
 namespace VLCB
 {
-  bool decodeGridConnect(const char * gcBuffer, CANFrame *frame);
-  bool encodeGridConnect(char * txBuffer, CANFrame *frame);
+  struct GCFrame
+  {
+  };
+  template <>
+  struct CANFrame<GCFrame>
+  {
+    uint32_t id;
+    bool ext;
+    bool rtr;
+    uint8_t len;
+    uint8_t data[8];    
+  };
+
+  bool decodeGridConnect(const char * gcBuffer, CANFrame<GCFrame> *frame);
+  bool encodeGridConnect(char * txBuffer, CANFrame<GCFrame> *frame);
 }

--- a/src/SerialGC.cpp
+++ b/src/SerialGC.cpp
@@ -85,7 +85,7 @@ namespace VLCB
   /// get the available CANMessage
   /// must call available first to ensure there is something to get
   //
-  CANFrame SerialGC::getNextCanFrame()
+  CANFrame<GCFrame> SerialGC::getNextCanFrame()
   {
     return rxCANFrame;
   }
@@ -95,7 +95,7 @@ namespace VLCB
   /// send a CANMessage message in GridConnect format
   // see Gridconnect format at beginning of file for byte positions
   //
-  bool SerialGC::sendCanFrame(CANFrame *frame)
+  bool SerialGC::sendCanFrame(CANFrame<GCFrame> *frame)
   {
     transmitCount++;
     bool result = encodeGridConnect(txBuffer, frame);

--- a/src/SerialGC.h
+++ b/src/SerialGC.h
@@ -24,15 +24,15 @@ namespace VLCB
   /// to support the gridconnect protocol over serial
   //
 
-  class SerialGC : public CanTransport
+  class SerialGC : public CanTransport<GCFrame>
   {
   public:
 
     bool begin();
 
     bool available() override;
-    CANFrame getNextCanFrame() override;
-    bool sendCanFrame(CANFrame *frame) override;
+    CANFrame<GCFrame> getNextCanFrame() override;
+    bool sendCanFrame(CANFrame<GCFrame> *frame) override;
     void reset() override;
 
     unsigned int receiveCounter() override { return receivedCount; }
@@ -46,14 +46,14 @@ namespace VLCB
 
     char rxBuffer[RXBUFFERSIZE]; // Define a byte array to store the incoming data
     char txBuffer[RXBUFFERSIZE]; // Define a byte array to store the outgoing data
-    CANFrame rxCANFrame;
+    CANFrame<GCFrame> rxCANFrame;
 
     unsigned int receivedCount = 0;
     unsigned int transmitCount = 0;
     unsigned int receiveErrorCount = 0;
     unsigned int transmitErrorCount = 0;
 
-    void debugCANMessage(CANFrame frame);
+    void debugCANMessage(CANFrame<GCFrame> frame);
 
   };
 

--- a/test/MockCanTransport.cpp
+++ b/test/MockCanTransport.cpp
@@ -12,14 +12,14 @@ bool MockCanTransport::available()
   return !incoming_frames.empty();
 }
 
-VLCB::CANFrame MockCanTransport::getNextCanFrame()
+VLCB::CANFrame<MockCanFrame> MockCanTransport::getNextCanFrame()
 {
-  VLCB::CANFrame msg = incoming_frames.front();
+  VLCB::CANFrame<MockCanFrame> msg = incoming_frames.front();
   incoming_frames.pop_front();
   return msg;
 }
 
-bool MockCanTransport::sendCanFrame(VLCB::CANFrame *frame)
+bool MockCanTransport::sendCanFrame(VLCB::CANFrame<MockCanFrame> *frame)
 {
   sent_frames.push_back(*frame);
   return true;
@@ -30,7 +30,7 @@ void MockCanTransport::reset()
 
 }
 
-void MockCanTransport::setNextMessage(VLCB::CANFrame frame)
+void MockCanTransport::setNextMessage(VLCB::CANFrame<MockCanFrame> frame)
 {
   incoming_frames.push_back(frame);
 }

--- a/test/MockCanTransport.h
+++ b/test/MockCanTransport.h
@@ -16,17 +16,42 @@
 
 struct MockCanFrame
 {
-
-};
-
-template <>
-struct VLCB::CANFrame<MockCanFrame>
-{
   uint32_t id;
   bool ext;
   bool rtr;
   uint8_t len;
   uint8_t data[8];
+};
+
+template <>
+struct VLCB::CANFrame<MockCanFrame>
+{
+  CANFrame() {}
+  CANFrame(int id, bool ext, bool rtr, int len, std::initializer_list<byte> il)
+  {
+    msg.id = id;
+    msg.ext = ext;
+    msg.rtr = rtr;
+    msg.len = len;
+    memcpy(msg.data, il.begin(), len);
+  }
+
+  MockCanFrame &getMessage() { return msg; }
+
+  uint32_t id() const { return msg.id; }
+  bool ext() const { return msg.ext; }
+  bool rtr() const { return msg.rtr; }
+  byte len() const { return msg.len; }
+  const byte *data() const { return msg.data; }
+
+  void id(uint32_t id) { msg.id = id; }
+  void ext(bool ext) { msg.ext = ext; }
+  void rtr(bool rtr) { msg.rtr = rtr; }
+  void len(byte len) { msg.len = len; }
+  byte *data() { return msg.data; }
+
+private:
+  MockCanFrame msg;
 };
 
 // This is to replace the hardware layer. It uses the CanTransport class for CAN processing.

--- a/test/MockCanTransport.h
+++ b/test/MockCanTransport.h
@@ -13,13 +13,29 @@
 #include "Controller.h"
 #include "CanTransport.h"
 
+
+struct MockCanFrame
+{
+
+};
+
+template <>
+struct VLCB::CANFrame<MockCanFrame>
+{
+  uint32_t id;
+  bool ext;
+  bool rtr;
+  uint8_t len;
+  uint8_t data[8];
+};
+
 // This is to replace the hardware layer. It uses the CanTransport class for CAN processing.
-class MockCanTransport : public VLCB::CanTransport
+class MockCanTransport : public VLCB::CanTransport<MockCanFrame>
 {
 public:
   virtual bool available() override;
-  virtual VLCB::CANFrame getNextCanFrame() override;
-  virtual bool sendCanFrame(VLCB::CANFrame *frame) override;
+  virtual VLCB::CANFrame<MockCanFrame> getNextCanFrame() override;
+  virtual bool sendCanFrame(VLCB::CANFrame<MockCanFrame> *frame) override;
   
   virtual void reset() override;
 
@@ -29,9 +45,9 @@ public:
   virtual unsigned int transmitErrorCounter() override { return 0; }
   virtual unsigned int errorStatus() override { return 0; }
 
-  void setNextMessage(VLCB::CANFrame frame);
+  void setNextMessage(VLCB::CANFrame<MockCanFrame> frame);
   void clearMessages();
 
-  std::deque<VLCB::CANFrame> incoming_frames;
-  std::vector<VLCB::CANFrame> sent_frames;
+  std::deque<VLCB::CANFrame<MockCanFrame>> incoming_frames;
+  std::vector<VLCB::CANFrame<MockCanFrame>> sent_frames;
 };

--- a/test/testCanService.cpp
+++ b/test/testCanService.cpp
@@ -53,18 +53,18 @@ void testServiceDiscovery()
   // Verify sent messages.
   assertEquals(3, mockCanTransport->sent_frames.size());
 
-  assertEquals(OPC_SD, mockCanTransport->sent_frames[0].data[0]);
-  assertEquals(2, mockCanTransport->sent_frames[0].data[5]); // Number of services
+  assertEquals(OPC_SD, mockCanTransport->sent_frames[0].data()[0]);
+  assertEquals(2, mockCanTransport->sent_frames[0].data()[5]); // Number of services
 
-  assertEquals(OPC_SD, mockCanTransport->sent_frames[1].data[0]);
-  assertEquals(1, mockCanTransport->sent_frames[1].data[3]); // index
-  assertEquals(SERVICE_ID_MNS, mockCanTransport->sent_frames[1].data[4]); // service ID
-  assertEquals(1, mockCanTransport->sent_frames[1].data[5]); // version
+  assertEquals(OPC_SD, mockCanTransport->sent_frames[1].data()[0]);
+  assertEquals(1, mockCanTransport->sent_frames[1].data()[3]); // index
+  assertEquals(SERVICE_ID_MNS, mockCanTransport->sent_frames[1].data()[4]); // service ID
+  assertEquals(1, mockCanTransport->sent_frames[1].data()[5]); // version
 
-  assertEquals(OPC_SD, mockCanTransport->sent_frames[2].data[0]);
-  assertEquals(2, mockCanTransport->sent_frames[2].data[3]); // index
-  assertEquals(SERVICE_ID_CAN, mockCanTransport->sent_frames[2].data[4]); // service ID
-  assertEquals(1, mockCanTransport->sent_frames[2].data[5]); // version
+  assertEquals(OPC_SD, mockCanTransport->sent_frames[2].data()[0]);
+  assertEquals(2, mockCanTransport->sent_frames[2].data()[3]); // index
+  assertEquals(SERVICE_ID_CAN, mockCanTransport->sent_frames[2].data()[4]); // service ID
+  assertEquals(1, mockCanTransport->sent_frames[2].data()[5]); // version
 }
 
 void testServiceDiscoveryCanSvc()
@@ -80,9 +80,9 @@ void testServiceDiscoveryCanSvc()
 
   // Verify sent messages.
   assertEquals(1, mockCanTransport->sent_frames.size());
-  assertEquals(OPC_ESD, mockCanTransport->sent_frames[0].data[0]);
-  assertEquals(2, mockCanTransport->sent_frames[0].data[3]); // index
-  assertEquals(SERVICE_ID_CAN, mockCanTransport->sent_frames[0].data[4]); // service ID
+  assertEquals(OPC_ESD, mockCanTransport->sent_frames[0].data()[0]);
+  assertEquals(2, mockCanTransport->sent_frames[0].data()[3]); // index
+  assertEquals(SERVICE_ID_CAN, mockCanTransport->sent_frames[0].data()[4]); // service ID
   // Not testing service data bytes.
 }
 
@@ -103,8 +103,8 @@ void testCanidEnumerationOnUserAction()
 
   // Expect message to make other modules report their CANID's
   assertEquals(1, mockCanTransport->sent_frames.size());
-  assertEquals(true, mockCanTransport->sent_frames[0].rtr);
-  assertEquals(0, mockCanTransport->sent_frames[0].len);
+  assertEquals(true, mockCanTransport->sent_frames[0].rtr());
+  assertEquals(0, mockCanTransport->sent_frames[0].len());
 
   // Processing after enumeration timeout
   addMillis(101);
@@ -134,12 +134,12 @@ void testCanidEnumerationOnSetUp()
   // Expect message to make other modules report their CANID's
   assertEquals(2, mockCanTransport->sent_frames.size());
 
-  assertEquals(true, mockCanTransport->sent_frames[0].rtr);
-  assertEquals(0, mockCanTransport->sent_frames[0].len);
+  assertEquals(true, mockCanTransport->sent_frames[0].rtr());
+  assertEquals(0, mockCanTransport->sent_frames[0].len());
 
-  assertEquals(OPC_RQNN, mockCanTransport->sent_frames[1].data[0]);
-  assertEquals(0, mockCanTransport->sent_frames[1].data[1]);
-  assertEquals(0, mockCanTransport->sent_frames[1].data[2]);
+  assertEquals(OPC_RQNN, mockCanTransport->sent_frames[1].data()[0]);
+  assertEquals(0, mockCanTransport->sent_frames[1].data()[1]);
+  assertEquals(0, mockCanTransport->sent_frames[1].data()[2]);
 
   // Processing after enumeration timeout
   addMillis(101);
@@ -169,8 +169,8 @@ void testCanidEnumerationOnENUM()
 
   // Expect message to make other modules report their CANID's
   assertEquals(1, mockCanTransport->sent_frames.size());
-  assertEquals(true, mockCanTransport->sent_frames[0].rtr);
-  assertEquals(0, mockCanTransport->sent_frames[0].len);
+  assertEquals(true, mockCanTransport->sent_frames[0].rtr());
+  assertEquals(0, mockCanTransport->sent_frames[0].len());
 
   // Processing after enumeration timeout
   addMillis(101);
@@ -178,7 +178,7 @@ void testCanidEnumerationOnENUM()
   process(controller);
 
   assertEquals(1, mockCanTransport->sent_frames.size());
-  assertEquals(OPC_NNACK, mockCanTransport->sent_frames[0].data[0]);
+  assertEquals(OPC_NNACK, mockCanTransport->sent_frames[0].data()[0]);
 
   // Expect first available CANID
   assertEquals(1, controller.getModuleCANID());
@@ -198,8 +198,8 @@ void testCanidEnumerationOnConflict()
 
   // Expect message to make other modules report their CANID's
   assertEquals(1, mockCanTransport->sent_frames.size());
-  assertEquals(true, mockCanTransport->sent_frames[0].rtr);
-  assertEquals(0, mockCanTransport->sent_frames[0].len);
+  assertEquals(true, mockCanTransport->sent_frames[0].rtr());
+  assertEquals(0, mockCanTransport->sent_frames[0].len());
 
   // Processing after enumeration timeout
   addMillis(101);
@@ -226,9 +226,9 @@ void testRtrMessage()
 
   // Verify sent messages.
   assertEquals(1, mockCanTransport->sent_frames.size());
-  assertEquals(0, mockCanTransport->sent_frames[0].len);
-  assertEquals(false, mockCanTransport->sent_frames[0].rtr);
-  assertEquals(3, mockCanTransport->sent_frames[0].id & 0x7F);
+  assertEquals(0, mockCanTransport->sent_frames[0].len());
+  assertEquals(false, mockCanTransport->sent_frames[0].rtr());
+  assertEquals(3, mockCanTransport->sent_frames[0].id() & 0x7F);
 }
 
 void testFindFreeCanidOnPopulatedBus()
@@ -248,8 +248,8 @@ void testFindFreeCanidOnPopulatedBus()
 
   // Expect message to make other modules report their CANID's
   assertEquals(1, mockCanTransport->sent_frames.size());
-  assertEquals(true, mockCanTransport->sent_frames[0].rtr);
-  assertEquals(0, mockCanTransport->sent_frames[0].len);
+  assertEquals(true, mockCanTransport->sent_frames[0].rtr());
+  assertEquals(0, mockCanTransport->sent_frames[0].len());
   mockCanTransport->sent_frames.clear();
 
   // Simulate other nodes
@@ -285,11 +285,11 @@ void testCANID()
   process(controller);
 
   assertEquals(2, mockCanTransport->sent_frames.size());
-  assertEquals(OPC_WRACK, mockCanTransport->sent_frames[0].data[0]);
-  assertEquals(OPC_GRSP, mockCanTransport->sent_frames[1].data[0]);
-  assertEquals(OPC_CANID, mockCanTransport->sent_frames[1].data[3]);
-  assertEquals(SERVICE_ID_CAN, mockCanTransport->sent_frames[1].data[4]);
-  assertEquals(GRSP_OK, mockCanTransport->sent_frames[1].data[5]);
+  assertEquals(OPC_WRACK, mockCanTransport->sent_frames[0].data()[0]);
+  assertEquals(OPC_GRSP, mockCanTransport->sent_frames[1].data()[0]);
+  assertEquals(OPC_CANID, mockCanTransport->sent_frames[1].data()[3]);
+  assertEquals(SERVICE_ID_CAN, mockCanTransport->sent_frames[1].data()[4]);
+  assertEquals(GRSP_OK, mockCanTransport->sent_frames[1].data()[5]);
 
   // Expect first available CANID
   assertEquals(33, controller.getModuleCANID());

--- a/test/testCanService.cpp
+++ b/test/testCanService.cpp
@@ -30,8 +30,8 @@ VLCB::Controller createController()
 
   mockCanTransport.reset(new MockCanTransport);
 
-  static std::unique_ptr<VLCB::CanService> canService;
-  canService.reset(new VLCB::CanService(mockCanTransport.get()));
+  static std::unique_ptr<VLCB::CanService<MockCanFrame>> canService;
+  canService.reset(new VLCB::CanService<MockCanFrame>(mockCanTransport.get()));
 
   VLCB::Controller controller = ::createController({minimumNodeService.get(), canService.get()});
   controller.begin();
@@ -45,7 +45,7 @@ void testServiceDiscovery()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 0}};
+  VLCB::CANFrame<MockCanFrame> msg = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 0}};
   mockCanTransport->setNextMessage(msg);
 
   process(controller);
@@ -73,7 +73,7 @@ void testServiceDiscoveryCanSvc()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 2}};
+  VLCB::CANFrame<MockCanFrame> msg = {0x11, false, false, 4, {OPC_RQSD, 0x01, 0x04, 2}};
   mockCanTransport->setNextMessage(msg);
 
   process(controller);
@@ -162,7 +162,7 @@ void testCanidEnumerationOnENUM()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_ENUM, 0x01, 0x04, 2}};
+  VLCB::CANFrame<MockCanFrame> msg = {0x11, false, false, 4, {OPC_ENUM, 0x01, 0x04, 2}};
   mockCanTransport->setNextMessage(msg);
 
   process(controller);
@@ -191,7 +191,7 @@ void testCanidEnumerationOnConflict()
   VLCB::Controller controller = createController();
   controller.getModuleConfig()->setCANID(3);
 
-  VLCB::CANFrame msg = {3, false, false, 1, {OPC_RQNP}};
+  VLCB::CANFrame<MockCanFrame> msg = {3, false, false, 1, {OPC_RQNP}};
   mockCanTransport->setNextMessage(msg);
 
   process(controller);
@@ -219,7 +219,7 @@ void testRtrMessage()
   VLCB::Controller controller = createController();
   controller.getModuleConfig()->CANID = 3;
 
-  VLCB::CANFrame msg = {0x11, false, true, 0, {}};
+  VLCB::CANFrame<MockCanFrame> msg = {0x11, false, true, 0, {}};
   mockCanTransport->setNextMessage(msg);
 
   process(controller);
@@ -255,7 +255,7 @@ void testFindFreeCanidOnPopulatedBus()
   // Simulate other nodes
   for (byte remoteCanid = 1 ; remoteCanid <= 19 ; ++remoteCanid)
   {
-    VLCB::CANFrame msg = {remoteCanid, false, false, 0, {}};
+    VLCB::CANFrame<MockCanFrame> msg = {remoteCanid, false, false, 0, {}};
     mockCanTransport->setNextMessage(msg);
     controller.process();
     mockCanTransport->incoming_frames.clear();
@@ -279,7 +279,7 @@ void testCANID()
 
   VLCB::Controller controller = createController();
 
-  VLCB::CANFrame msg = {0x11, false, false, 4, {OPC_CANID, 0x01, 0x04, 33}};
+  VLCB::CANFrame<MockCanFrame> msg = {0x11, false, false, 4, {OPC_CANID, 0x01, 0x04, 33}};
   mockCanTransport->setNextMessage(msg);
 
   process(controller);

--- a/test/testGridConnect.cpp
+++ b/test/testGridConnect.cpp
@@ -4,7 +4,7 @@
 
 #include "GridConnect.h"
 
-void debugCANMessage(VLCB::CANFrame frame)
+void debugCANMessage(VLCB::CANFrame<VLCB::GCFrame> frame)
 {
   std::cout << std::endl << "VLCB::CANFrame:";
   std::cout << " id " << frame.id << " length " << frame.len;
@@ -23,7 +23,7 @@ void testGridConnectEncode_StandardID(int ID, const char * expectedMessage, bool
 {
   test();
   char msgBuffer[28]; 
-  VLCB::CANFrame frame;
+  VLCB::CANFrame<VLCB::GCFrame> frame;
   frame.ext = false;
   frame.len = 2;
   frame.rtr = false;
@@ -44,7 +44,7 @@ void testGridConnectEncode_ExtendedID(int ID, const char * expectedMessage, bool
 {
   test();
   char msgBuffer[28]; 
-  VLCB::CANFrame frame;
+  VLCB::CANFrame<VLCB::GCFrame> frame;
   frame.ext = true;
   frame.len = 2;
   frame.rtr = false;
@@ -65,7 +65,7 @@ void testGridConnectEncode_RTR(bool rtr, const char * expectedMessage, bool expe
 {
   test();
   char msgBuffer[28]; 
-  VLCB::CANFrame frame;
+  VLCB::CANFrame<VLCB::GCFrame> frame;
   frame.ext = false;
   frame.len = 2;
   frame.rtr = rtr;
@@ -85,7 +85,7 @@ void testGridConnectEncode_DATA(int len, const char * expectedMessage, bool expe
 {
   test();
   char msgBuffer[30]; 
-  VLCB::CANFrame frame;
+  VLCB::CANFrame<VLCB::GCFrame> frame;
   frame.ext = false;
   frame.len = len;
   frame.rtr = false;
@@ -107,7 +107,7 @@ void testGridConnectEncode_DATA(int len, const char * expectedMessage, bool expe
 void testGridConnectDecode_ID(const char * inputMessage, bool expectedEXT, int expectedID, bool expectedResult)
 {
   test();
-  VLCB::CANFrame frame;
+  VLCB::CANFrame<VLCB::GCFrame> frame;
   bool result = VLCB::decodeGridConnect(inputMessage, &frame);
 
   assertEquals(expectedResult, result);
@@ -122,7 +122,7 @@ void testGridConnectDecode_ID(const char * inputMessage, bool expectedEXT, int e
 void testGridConnectDecode_RTR(const char * inputMessage, bool expectedRTR, bool expectedResult)
 {
   test();
-  VLCB::CANFrame frame;
+  VLCB::CANFrame<VLCB::GCFrame> frame;
   bool result = VLCB::decodeGridConnect(inputMessage, &frame);
 
   assertEquals(expectedResult, result);
@@ -135,7 +135,7 @@ void testGridConnectDecode_RTR(const char * inputMessage, bool expectedRTR, bool
 void testGridConnectDecode_DATA(const char * inputMessage, int expectedLEN, bool expectedResult)
 {
   test();
-  VLCB::CANFrame frame;
+  VLCB::CANFrame<VLCB::GCFrame> frame;
   bool result = VLCB::decodeGridConnect(inputMessage, &frame);
 
   assertEquals(expectedResult, result);


### PR DESCRIPTION
Duncan floated an idea of making use of templates to avoid copying between CANFrame and the implementation specific CAN data.

The key changes are for CANFrame (defined in CanTransport.h) that is now a template struct. It has no data members as this will be provided by specializations, for example CANFrame<CANMessage> in CAN2515.h. The main idea is that when interacting with the underlying CAN library we expose its data structure to that library. This datastructure is embedded in the CANFrame so that CanService can work with it. This is why CanService is also a template class.

I had been toying with making CANFrame polymorphic and have all the CAN data in the specific child classes. As above there would not be any copying between the specific CAN data and CANFrame. But this means that all access to that data is done via virtual functions. The template solution here does not need the virtual functions. The data access methods are all inline functions so they are efficient.