### PR TITLE
SerialGC changes

### DIFF
--- a/src/SerialGC.cpp
+++ b/src/SerialGC.cpp
@@ -34,9 +34,9 @@ namespace VLCB
   {
     bool result = false;
     static int rxIndex = 0;
-    if (Serial.available())
+    if (serial.available())
     {     
-      char c = Serial.read();
+      char c = serial.read();
       c = toupper(c);
       //
       // if 'start of message' already seen, save the character, and check for 'end of message'
@@ -102,7 +102,7 @@ namespace VLCB
     if (result)
     {
       // output the message
-      Serial.print(txBuffer);
+      serial.print(txBuffer);
     }
     else
     {

--- a/src/SerialGC.h
+++ b/src/SerialGC.h
@@ -27,7 +27,7 @@ namespace VLCB
   class SerialGC : public CanTransport
   {
   public:
-
+    SerialGC(typeof(Serial)& _serial = Serial) : serial(_serial) {}
     bool begin();
 
     bool available() override;
@@ -43,7 +43,8 @@ namespace VLCB
 
 
   private:
-
+    typeof(Serial)& serial;
+	
     char rxBuffer[RXBUFFERSIZE]; // Define a byte array to store the incoming data
     char txBuffer[RXBUFFERSIZE]; // Define a byte array to store the outgoing data
     CANFrame rxCANFrame;


### PR DESCRIPTION
Allow for  different serial ports. These changes allow MEGA and DUE compiles to use Serial1, Serial2 or Serial3 instead of Serial.