### PR TITLE
Add SimpleCLIUserInterface to VLCB-Arduino

### DIFF
--- a/examples/VLCB_1in1out_SimpleCLI_MEGA/README.md
+++ b/examples/VLCB_1in1out_SimpleCLI_MEGA/README.md
@@ -1,0 +1,53 @@
+# VLCB_1in1out_SimpleCLI_MEGA
+
+This code demonstrates the use of the VLCB SimpleCLIUserInterface as an alternative to the SerialUserInterface.
+
+This is made possible by the use of the third party library SimpleCLI to define commands and a help system.
+
+This code is too large to run on an Arduino UNO or NANO and has been set to compile for a MEGA 1280 or MEGA 2560.
+
+## SimpleCLI
+
+This library enables commands with optional parameters on the Serial interface.
+
+https://github.com/SpacehuhnTech/SimpleCLI
+
+It is possible for the commands to execute a callback function within the user code.
+
+## Motivation
+
+The origins of the SerialUserInterface for VLCB lie in the development of a serial interface for Arduino CBUS applications. The idea of this is to allow the user to configure the module using the serial interface of the Arduino IDE. In the CBUS version the code to process the input is included in the application.
+
+The VLCB SerialUserInterface has been developed to provide a similar interface for the VLCB-Arduino library. This is be provided as a separate service.
+
+SimpleCLIUserInterface is an alternative to the SerialUserInterface which allows for much more flexibility in what can be input using the serial interface.
+
+With the SerialUserInterface the commands are single characters.
+
+SimpleCLIUserInterface allow for word commands which can have parameters in various combinations. The commands can also run callback functions and this has been used to implement the single letter commands available in the SerialUserInterface.
+
+Several different commands can be combined together e.g. "a,b,c" will respond to "a" or "b" or "c".
+
+## Example
+
+This example shows how the interface can be use to construct a help system for VLCB examples.
+
+It is also possible for the user to add commands to the help system.
+
+The available help commands are: help, helpAbout.
+
+There is also a command which provides the single character commands for the VLCB interface:
+
+n,e,v,c,h,y,s,z,*
+
+These are the same as in the SerialUserInterface except for an added "z".
+
+There are two examples of user added commands:
+
+some/thing  - this will respond to "some" or "something".
+
+a,b  - this will respond to "a" or "b"
+
+## Assistance and help
+
+For assistance with this code please contact John Fletcher <M6777> john@bunbury28.plus.com

--- a/examples/VLCB_1in1out_SimpleCLI_MEGA/VLCB_1in1out_SimpleCLI_MEGA.ino
+++ b/examples/VLCB_1in1out_SimpleCLI_MEGA/VLCB_1in1out_SimpleCLI_MEGA.ino
@@ -1,0 +1,320 @@
+// VLCB_1in1out_SimpleCLI_MEGA.ino
+// Example using SimpleCLI interface to provide commands and a help system using the Serial interface.
+// For more details see the README file with this code.
+
+// This code example is too large to run on an Arduino UNO or NANO which is why it has MEGA in the name.
+// It will run on a MEGA 1280 or MEGA 2560 and has been set not to compile on a UNO or NANO.
+
+//  Copyright (C) Sven Rosvall (sven@rosvall.ie)
+//  This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+//  Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+//  The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0
+
+/*
+      3rd party libraries needed for compilation: (not for binary-only distributions)
+
+      Streaming   -- C++ stream style output, v5, (http://arduiniana.org/libraries/streaming/)
+      ACAN2515    -- library to support the MCP2515/25625 CAN controller IC
+*/
+
+
+// Define for either 1280 or 2560 MEGA
+#if defined(ARDUINO_AVR_MEGA2560) || defined(ARDUINO_AVR_MEGA)
+#define ARDUINO_MEGA
+#else
+#error "This code will not run on an Arduino UNO or NANO. It is too big."
+#endif
+
+// 3rd party libraries
+#include <Streaming.h>
+
+// VLCB library header files
+#include <Controller.h>                   // Controller class
+#include <CAN2515.h>               // CAN controller
+#include <Switch.h>             // pushbutton switch
+#include <LED.h>                // VLCB LEDs
+#include <Configuration.h>             // module configuration
+#include <Parameters.h>             // VLCB parameters
+#include <vlcbdefs.hpp>               // VLCB constants
+#include "MinimumNodeService.h"
+#include "CanService.h"
+#include "NodeVariableService.h"
+#include "EventConsumerService.h"
+#include "EventProducerService.h"
+#include "ConsumeOwnEventsService.h"
+#include "EventTeachingService.h"
+#include "SimpleCLIUserInterface.h"
+
+// constants
+const byte VER_MAJ = 1;             // code major version
+const char VER_MIN = 'a';           // code minor version
+const byte VER_BETA = 0;            // code beta sub-version
+const byte MANUFACTURER = MANU_DEV; // for boards in development.
+const byte MODULE_ID = 99;          // VLCB module type
+
+const byte LED_GRN = 4;             // VLCB green Unitialised LED pin
+const byte LED_YLW = 7;             // VLCB yellow Normal LED pin
+const byte SWITCH0 = 8;             // VLCB push button switch pin
+
+// Controller objects
+VLCB::Configuration modconfig;               // configuration object
+VLCB::CAN2515 can2515;                  // CAN transport object
+//VLCB::LEDUserInterface ledUserInterface(LED_GRN, LED_YLW, SWITCH0);
+VLCB::SimpleCLIUserInterface simpleCLIUserInterface(&can2515);
+VLCB::MinimumNodeService mnService;
+VLCB::CanService canService(&can2515);
+VLCB::NodeVariableService nvService;
+VLCB::ConsumeOwnEventsService coeService;
+VLCB::EventConsumerService ecService;
+VLCB::EventTeachingService etService;
+VLCB::EventProducerService epService;
+VLCB::Controller controller(&modconfig, 
+                            {&mnService, &simpleCLIUserInterface, &canService, &nvService, &ecService, &epService, &etService, &coeService}); // Controller object
+
+// module objects
+VLCB::Switch moduleSwitch(5);            // an example switch as input
+VLCB::LED moduleLED(6);                  // an example LED as output
+
+// module name, must be 7 characters, space padded.
+unsigned char mname[7] = { '1', 'I', 'N', '1', 'O', 'U', 'T' };
+
+// forward function declarations
+void eventhandler(byte, const VLCB::VlcbMessage *);
+void printConfig();
+void processModuleSwitchChange();
+
+//
+/// setup VLCB - runs once at power on from setup()
+//
+void setupVLCB()
+{
+  // set config layout parameters
+  modconfig.EE_NVS_START = 10;
+  modconfig.EE_NUM_NVS = 10;
+  modconfig.EE_EVENTS_START = 20;
+  modconfig.EE_MAX_EVENTS = 32;
+  modconfig.EE_PRODUCED_EVENTS = 1;
+  modconfig.EE_NUM_EVS = 2; // EV1: Produced event ; EV2: LED1
+ 
+
+  // initialise and load configuration
+  controller.begin();
+
+  const char * modeString;
+  switch (modconfig.currentMode)
+  {
+    case MODE_NORMAL: modeString = "Normal"; break;
+    case MODE_SETUP: modeString = "Setup"; break;
+    case MODE_UNINITIALISED: modeString = "Uninitialised"; break;
+    default: modeString = "Unknown"; break;
+  }
+  Serial << F("> mode = (") << _HEX(modconfig.currentMode) << ") " << modeString;
+  Serial << F(", CANID = ") << modconfig.CANID;
+  Serial << F(", NN = ") << modconfig.nodeNum << endl;
+
+  // show code version and copyright notice
+  printConfig();
+
+  // set module parameters
+  VLCB::Parameters params(modconfig);
+  params.setVersion(VER_MAJ, VER_MIN, VER_BETA);
+  params.setManufacturer(MANUFACTURER);
+  params.setModuleId(MODULE_ID);  
+ 
+  // assign to Controller
+  controller.setParams(params.getParams());
+  controller.setName(mname);
+
+  // module reset - if switch is depressed at startup
+  //if (ledUserInterface.isButtonPressed())
+  // {
+  // Serial << F("> switch was pressed at startup") << endl;
+  //  modconfig.resetModule();
+  //}
+
+  // register our VLCB event handler, to receive event messages of learned events
+  ecService.setEventHandler(eventhandler);
+
+  // set Controller LEDs to indicate the current mode
+  controller.indicateMode(modconfig.currentMode);
+
+  // configure and start CAN bus and VLCB message processing
+  can2515.setNumBuffers(2, 1);      // more buffers = more memory used, fewer = less
+  can2515.setOscFreq(16000000UL);   // select the crystal frequency of the CAN module
+  can2515.setPins(10, 2);           // select pins for CAN bus CE and interrupt connections
+  if (!can2515.begin())
+  {
+    Serial << F("> error starting VLCB") << endl;
+  } else {
+    Serial << F("> VLCB started") << endl;
+  }
+
+  simpleCLIUserInterface.setupHelp();
+  more_commands();
+
+}
+
+// These are new commands being declared.
+Command cmdNew;
+Command cmdAB;
+
+void say_something(cmd *c)
+{
+  Command cmd(c); // Create wrapper object
+  Serial.println(cmd.toString());
+  Serial << "Something or other" << endl;
+}
+
+void callAB(cmd *c)
+{
+  Command cmd(c); // Create wrapper object
+  // This makes it possible to do different things depending on the value.
+  char firstChar = simpleCLIUserInterface.getFirstChar();
+  Serial << "called as " << firstChar << " : ";
+  Serial.println(cmd.toString());
+  Serial  << "AB called" << endl;
+}
+
+// This is how to declare new commands.
+void more_commands() {
+  // Add the command to the VLCB::cli object.
+  cmdNew = VLCB::simpleCli.addCommand("some/thing",say_something);
+  cmdNew.setDescription(" This is a new command!");
+  cmdAB = VLCB::simpleCli.addCommand("a,b",callAB);
+  cmdAB.setDescription(" This shows a,b in use.");
+}
+
+//
+/// setup - runs once at power on
+//
+void setup()
+{
+  Serial.begin (115200);
+  Serial << endl << endl << F("> ** VLCB 1in1out SimpleCLI v1 ** ") << endl;
+  Serial << F("> ") << __FILE__ << endl;
+
+  setupVLCB();
+
+  // end of setup
+  Serial << F("> ready") << endl << endl;
+}
+
+//
+/// loop - runs forever
+//
+void loop()
+{
+  //
+  /// do VLCB message, switch and LED processing
+  //
+  controller.process();
+
+  //
+  /// give the switch and LED code some time to run
+  //
+  moduleSwitch.run();
+  moduleLED.run();
+
+  //
+  /// Check if smich changed and do any processing for this change.
+  //
+  processModuleSwitchChange();
+
+  //
+  /// check CAN message buffers
+  //
+  if (can2515.canp->receiveBufferPeakCount() > can2515.canp->receiveBufferSize())
+  {
+    Serial << F("> receive buffer overflow") << endl;
+  }
+
+  if (can2515.canp->transmitBufferPeakCount(0) > can2515.canp->transmitBufferSize(0))
+  {
+    Serial << F("> transmit buffer overflow") << endl;
+  }
+
+  //
+  /// check CAN bus state
+  //
+  byte s = can2515.canp->errorFlagRegister();
+  if (s != 0)
+  {
+    Serial << F("> error flag register is non-zero") << endl;
+  }
+
+  // bottom of loop()
+}
+
+//
+/// test for switch input
+/// as an example, it must be have been pressed or released for at least half a second
+/// then send a long VLCB event with opcode ACON for on and ACOF for off
+
+/// you can just watch for this event in FCU or JMRI, or teach it to another VLCB consumer module
+//
+void processModuleSwitchChange()
+{
+  if (moduleSwitch.stateChanged())
+  {
+    bool state = moduleSwitch.isPressed();
+    byte inputChannel = 1;  
+    epService.sendEvent(state, inputChannel);
+  }
+}
+
+//
+/// user-defined event processing function
+/// called from the VLCB library when a learned event is received
+/// it receives the event table index and the CAN frame
+//
+void eventhandler(byte index, const VLCB::VlcbMessage *msg)
+{
+  // as an example, control an LED
+
+  byte evval = modconfig.getEventEVval(index, 2);  //read ev2 because ev1 defines producer.
+  // Event Off op-codes have odd numbers.
+  bool ison = (msg->data[0] & 0x01) == 0;
+
+  Serial << F("> event handler: index = ") << index << F(", opcode = 0x") << _HEX(msg->data[0]) << endl;
+  Serial << F("> EV2 = ") << evval << endl;
+
+  // set the LED according to the opcode of the received event, if the second EV equals 1
+  // we turn on the LED and if the first EV equals 2 we use the blink() method of the LED object as an example.
+  if (ison)
+  {
+    switch (evval)
+    {
+      case 1:
+        Serial << F("> switching the LED on") << endl;
+        moduleLED.on();
+        break;
+
+      case 2:
+        Serial << F("> switching the LED to blink") << endl;
+        moduleLED.blink();
+        break;
+    }
+  }
+  else
+  {
+    if (evval > 0)
+    {
+      Serial << F("> switching the LED off") << endl;
+      moduleLED.off();
+    }
+  }
+}
+
+//
+/// print code version config details and copyright notice
+//
+void printConfig()
+{
+  // code version
+  Serial << F("> code version = ") << VER_MAJ << VER_MIN << F(" beta ") << VER_BETA << endl;
+  Serial << F("> compiled on ") << __DATE__ << F(" at ") << __TIME__ << F(", compiler ver = ") << __cplusplus << endl;
+
+  // copyright
+  Serial << F("> © Duncan Greenwood (MERG M5767) 2019") << endl;
+  Serial << F("> © John Fletcher (MERG M6777) 2024") << endl;
+}

--- a/src/SimpleCLIUserInterface.cpp
+++ b/src/SimpleCLIUserInterface.cpp
@@ -17,20 +17,9 @@ namespace VLCB
 // Create CLI Object
 SimpleCLI simpleCli(CLI_COMMAND_QUEUE_SIZE); // Default of 10 commands
 
-// Callback function for exit command
-/*
-void exitHelpCallback(cmd* c) {
-    Command cmd(c); // Create wrapper object
-
-    Serial.println("Exit help");
-	// I need a way to exit the help system from here.
-}
-*/
-
 Command cmdHelp;
 Command cmdHelpWithArg;
 Command cmdSerialInterface;
-//Command cmdExit;
 
 //////////////////////////////////////////////////////////////////
 // See Modern C++ Design, Andrei Alexandrescu, 2001(!) page 116
@@ -76,7 +65,6 @@ void SimpleCLIUserInterface::serialCallback(cmd *c) {
 	// Copy the char into the instance.
 	serialChar = local_serialChar;
     Serial.print(serialChar);
-    //Serial.print(cmd.getName()); //(same as toString())
     Serial.print(" : ");
     Serial.println(cmd.toString());
 	processSerialInputImpl(serialChar); 
@@ -86,11 +74,8 @@ void local_serialCallback(cmd *c) {
     Command cmd(c); // Create wrapper object
     Serial.print("called as ");
     Serial.print(local_serialChar);
-    //Serial.print(cmd.getName()); //(same as toString())
     Serial.print(" : ");
     Serial.println(cmd.toString());
-	// How can I get access to the instance of simpleUserInterface??
-	// The answer is to use local_simpleUserInterface.
 	(simpleCLIUserInterface.*pSerialCallback)(c);
 }
 
@@ -109,15 +94,11 @@ void SimpleCLIUserInterface::setupHelp()
     cmdSerialInterface = simpleCli.addCommand("n,e,v,c,h,y,s,z,*",local_serialCallback);
 	cmdSerialInterface.setDescription("serial commands n, e, v, c, h, y, s, z and * for the module");
 	
-
-    //Serial.println(cli.toString());  // Prints all the help items.
     Serial.println("> VLCB help system started!!");
 }
 
 void SimpleCLIUserInterface::getHelp()
 {
-   //Serial << "VLCB help system available" << endl;
-	 // Ideally this should be in a separate task allowing other things to go on.
    if (Serial.available()) {
         String input = Serial.readStringUntil('\n');
 
@@ -169,8 +150,6 @@ void SimpleCLIUserInterface::getHelp()
 
 void SimpleCLIUserInterface::processSerialInput()
 {
-  //byte uev = 0;
-  //char msgstr[32], dstr[32];
 
   if (Serial.available())
   {
@@ -185,10 +164,6 @@ void SimpleCLIUserInterface::processSerialInputImpl(char c)
 {
   byte uev = 0;
   char msgstr[32], dstr[32];
-
-  //if (Serial.available())
-  //{
-  //  char c = Serial.read();
 
     switch (c)
     {
@@ -323,15 +298,11 @@ void SimpleCLIUserInterface::processSerialInputImpl(char c)
         Serial << endl;
         break;
 
-      //case 'x':
-	  //  getHelp();
-	  //break;
-
       default:
         Serial << F("> unknown command ") << c << endl;
         break;
     }
-//}
+
 }
 
 void SimpleCLIUserInterface::handleAction(const Action *action)

--- a/src/SimpleCLIUserInterface.cpp
+++ b/src/SimpleCLIUserInterface.cpp
@@ -1,0 +1,381 @@
+// Copyright (C) Sven Rosvall (sven@rosvall.ie)
+// This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+// Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+// The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0/
+
+#include "SimpleCLIUserInterface.h"
+#include "Controller.h"
+#include <Streaming.h>
+#include <SimpleCLI.h>
+
+extern void printConfig();
+
+
+namespace VLCB
+{
+
+// Create CLI Object
+SimpleCLI simpleCli(CLI_COMMAND_QUEUE_SIZE); // Default of 10 commands
+
+// Callback function for exit command
+/*
+void exitHelpCallback(cmd* c) {
+    Command cmd(c); // Create wrapper object
+
+    Serial.println("Exit help");
+	// I need a way to exit the help system from here.
+}
+*/
+
+Command cmdHelp;
+Command cmdHelpWithArg;
+Command cmdSerialInterface;
+//Command cmdExit;
+
+//////////////////////////////////////////////////////////////////
+// See Modern C++ Design, Andrei Alexandrescu, 2001(!) page 116
+// First declare a typedef for a pointer to what is needed.
+// Note the argument type.
+typedef void (SimpleCLIUserInterface::* TpMemFun)(cmd *);
+// Then create an object which implements tha callback
+TpMemFun pSerialCallback = &SimpleCLIUserInterface::serialCallback;
+// An instance of class SimpleUserInterace is also needed.
+// Where is it? Declared in the top level code.
+// This is the actual call to use the callback
+//     (simpleCLIUserInterface.*pSerialCallback)(c);
+// It is used in local_templateCallback(cmd *c) - see below.
+/////////////////////////////////////////////////////////////
+
+
+
+SimpleCLIUserInterface::SimpleCLIUserInterface(Transport *transport)
+  : transport(transport)
+{
+}
+
+void SimpleCLIUserInterface::setController(Controller *ctrl)
+{
+  this->controller = ctrl;
+  this->modconfig = ctrl->getModuleConfig();
+}
+
+void SimpleCLIUserInterface::process(const Action *action)
+{
+  handleAction(action);
+  
+  //This replaces processSerialInput(); 
+  getHelp();
+}
+
+// This will hold a local copy of the first char of the input.
+char local_serialChar = '0'; 
+
+void SimpleCLIUserInterface::serialCallback(cmd *c) {
+    Command cmd(c); // Create wrapper object
+    Serial.print("called as ");
+	// Copy the char into the instance.
+	serialChar = local_serialChar;
+    Serial.print(serialChar);
+    //Serial.print(cmd.getName()); //(same as toString())
+    Serial.print(" : ");
+    Serial.println(cmd.toString());
+	processSerialInputImpl(serialChar); 
+}
+
+void local_serialCallback(cmd *c) {
+    Command cmd(c); // Create wrapper object
+    Serial.print("called as ");
+    Serial.print(local_serialChar);
+    //Serial.print(cmd.getName()); //(same as toString())
+    Serial.print(" : ");
+    Serial.println(cmd.toString());
+	// How can I get access to the instance of simpleUserInterface??
+	// The answer is to use local_simpleUserInterface.
+	(simpleCLIUserInterface.*pSerialCallback)(c);
+}
+
+// This is called from setupVLCB().
+void SimpleCLIUserInterface::setupHelp()
+{
+    Serial << "> VLCB help system setting up" << endl;
+
+    cmdHelp = simpleCli.addCommand("help");
+    cmdHelp.setDescription(" Get help!");
+
+    cmdHelpWithArg = simpleCli.addCommand("helpAbout");
+    cmdHelpWithArg.addArg("topic","help");
+    cmdHelpWithArg.setDescription(" Get help on a topic!");
+
+    cmdSerialInterface = simpleCli.addCommand("n,e,v,c,h,y,s,z,*",local_serialCallback);
+	cmdSerialInterface.setDescription("serial commands n, e, v, c, h, y, s, z and * for the module");
+	
+
+    //Serial.println(cli.toString());  // Prints all the help items.
+    Serial.println("> VLCB help system started!!");
+}
+
+void SimpleCLIUserInterface::getHelp()
+{
+   //Serial << "VLCB help system available" << endl;
+	 // Ideally this should be in a separate task allowing other things to go on.
+   if (Serial.available()) {
+        String input = Serial.readStringUntil('\n');
+
+        if (input.length() > 0) {
+            Serial.print("# ");
+            Serial.println(input);
+            serialChar = input[0];
+            local_serialChar = serialChar;			
+            simpleCli.parse(input);
+        }
+    }
+
+    if (simpleCli.available()) {
+        Command c = simpleCli.getCmd();
+
+        int argNum = c.countArgs();
+
+        Serial.print("> ");
+        Serial.print(c.getName());
+        Serial.print(' ');
+
+        for (int i = 0; i<argNum; ++i) {
+            Argument arg = c.getArgument(i);
+            // if(arg.isSet()) {
+            Serial.print(arg.toString());
+            Serial.print(' ');
+            // }
+        }
+		
+		Serial.println();
+
+        if (c == cmdHelp) {
+            Serial.println("Help:");
+            Serial.println(simpleCli.toString());
+        } else if (c == cmdHelpWithArg) {
+            Serial.print("HelpAbout:");
+            Argument arg = c.getArgument(0);
+            Serial.println(arg.getValue());
+            Command cc = simpleCli.getCmd(arg.getValue());
+            if (cc.hasDescription()) {
+              Serial.println(cc.toString());
+            } else {
+              Serial.print("No description available for ");
+              Serial.println(arg.getValue());
+            }
+        }
+	}
+}
+
+void SimpleCLIUserInterface::processSerialInput()
+{
+  //byte uev = 0;
+  //char msgstr[32], dstr[32];
+
+  if (Serial.available())
+  {
+     char c = Serial.read();
+	 
+	 processSerialInputImpl(c);
+
+  }
+}
+
+void SimpleCLIUserInterface::processSerialInputImpl(char c)
+{
+  byte uev = 0;
+  char msgstr[32], dstr[32];
+
+  //if (Serial.available())
+  //{
+  //  char c = Serial.read();
+
+    switch (c)
+    {
+      case 'n':
+        // node config
+        printConfig();
+
+        // node identity
+        Serial << F("> VLCB node configuration") << endl;
+        Serial << F("> mode = ") << (modconfig->currentMode == MODE_NORMAL ? "Normal" : "Unitialised") << F(", CANID = ") << modconfig->CANID << F(", node number = ") << modconfig->nodeNum << endl;
+        Serial << endl;
+        break;
+
+      case 'e':
+        // EEPROM learned event data table
+        Serial << F("> stored events ") << endl;
+        Serial << F("  max events = ") << modconfig->EE_MAX_EVENTS << F(" EVs per event = ") << modconfig->EE_NUM_EVS << F(" bytes per event = ") << modconfig->EE_BYTES_PER_EVENT << endl;
+
+        for (byte j = 0; j < modconfig->EE_MAX_EVENTS; j++)
+        {
+          if (modconfig->getEvTableEntry(j) != 0)
+          {
+            ++uev;
+          }
+        }
+
+        Serial << F("  stored events = ") << uev << F(", free = ") << (modconfig->EE_MAX_EVENTS - uev) << endl;
+        Serial << F("  using ") << (uev * modconfig->EE_BYTES_PER_EVENT) << F(" of ") << (modconfig->EE_MAX_EVENTS * modconfig->EE_BYTES_PER_EVENT) << F(" bytes") << endl << endl;
+
+        Serial << F("  Ev#  |  NNhi |  NNlo |  ENhi |  ENlo | ");
+
+        for (byte j = 0; j < (modconfig->EE_NUM_EVS); j++)
+        {
+          sprintf(dstr, "EV%03d | ", j + 1);
+          Serial << dstr;
+        }
+
+        Serial << F("Hash |") << endl;
+        Serial << F(" --------------------------------------------------------------") << endl;
+
+        // for each event data line
+        for (byte j = 0; j < modconfig->EE_MAX_EVENTS; j++)
+        {
+          if (modconfig->getEvTableEntry(j) != 0)
+          {
+            sprintf(dstr, "  %03d  | ", j);
+            Serial << dstr;
+
+            // for each data byte of this event
+            byte evarray[4];
+            modconfig->readEvent(j, evarray);
+            for (byte e = 0; e < 4; e++)
+            {
+              sprintf(dstr, " 0x%02hx | ", evarray[e]);
+              Serial << dstr;
+            }
+            for (byte ev = 1; ev <= modconfig->EE_NUM_EVS; ev++)
+            {
+              sprintf(dstr, " 0x%02hx | ", modconfig->getEventEVval(j, ev));
+              Serial << dstr;
+            }
+
+            sprintf(dstr, "%4d |", modconfig->getEvTableEntry(j));
+            Serial << dstr << endl;
+          }
+        }
+
+        Serial << endl;
+
+        break;
+
+        // NVs
+      case 'v':
+        // note NVs number from 1, not 0
+        Serial << "> Node variables" << endl;
+        Serial << F("   NV   Val") << endl;
+        Serial << F("  --------------------") << endl;
+
+        for (byte j = 1; j <= modconfig->EE_NUM_NVS; j++)
+        {
+          byte v = modconfig->readNV(j);
+          sprintf(msgstr, " - %02d : %3hd | 0x%02hx", j, v, v);
+          Serial << msgstr << endl;
+        }
+
+        Serial << endl << endl;
+
+        break;
+
+        // CAN bus status
+      case 'c':
+        Serial << F(" messages received = ") << transport->receiveCounter()
+               << F(", sent = ") << transport->transmitCounter()
+               << F(", receive errors = ") << transport->receiveErrorCounter()
+               << F(", transmit errors = ") << transport->transmitErrorCounter()
+               << F(", error status = ") << transport->errorStatus()
+        << endl;
+        break;
+
+      case 'h':
+        // event hash table
+        modconfig->printEvHashTable(false);
+        break;
+
+      case 'y':
+        // reset CAN bus and VLCB message processing
+        transport->reset();
+        break;
+
+      case '*':
+        // reboot
+        modconfig->reboot();
+        break;
+
+      case 'z':
+        // reboot
+        modconfig->resetModule();
+        break;
+
+      case 'm':
+        // free memory
+        Serial << F("> free SRAM = ") << modconfig->freeSRAM() << F(" bytes") << endl;
+        break;
+        
+      case 's': // "s" == "setup"
+        //Serial << F("SUI> Requesting mode change") << endl; Serial.flush();
+        controller->putAction(ACT_CHANGE_MODE);
+        break;
+
+      case '\r':
+      case '\n':
+        Serial << endl;
+        break;
+
+      //case 'x':
+	  //  getHelp();
+	  //break;
+
+      default:
+        Serial << F("> unknown command ") << c << endl;
+        break;
+    }
+//}
+}
+
+void SimpleCLIUserInterface::handleAction(const Action *action)
+{
+  if (action == nullptr)
+  {
+    return;
+  }
+
+  switch (action->actionType)
+  {
+    case ACT_INDICATE_ACTIVITY:
+      // Don't indicate this. Too noisy.
+      break;
+
+    case ACT_INDICATE_MODE:
+      indicateMode(action->mode);
+      break;
+
+    default:
+      break;
+  }
+}
+
+void SimpleCLIUserInterface::indicateMode(VlcbModeParams mode) 
+{
+  switch (mode) 
+  {
+
+    case MODE_NORMAL:
+      Serial << "Module in NORMAL mode" << endl;
+      break;
+
+    case MODE_UNINITIALISED:
+      Serial << "Module in UNINITIALISED mode" << endl;
+      break;
+
+    case MODE_SETUP:
+      Serial << "Module in SETUP mode" << endl;
+      break;
+
+    default:
+      break;
+  }
+}
+
+}

--- a/src/SimpleCLIUserInterface.h
+++ b/src/SimpleCLIUserInterface.h
@@ -1,0 +1,60 @@
+// Copyright (C) Sven Rosvall (sven@rosvall.ie)
+// This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+// Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+// The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0/
+
+#pragma once
+
+#include "Service.h"
+#include "Configuration.h"
+#include "Transport.h"
+#include <SimpleCLI.h>
+
+#define CLI_COMMAND_QUEUE_SIZE 10 
+
+namespace VLCB
+{
+
+class SimpleCLIUserInterface : public Service
+{
+public:
+  SimpleCLIUserInterface(Transport *transport);
+  virtual void setController(Controller *ctrl) override;
+  virtual byte getServiceID() override { return 0; };
+  virtual byte getServiceVersionID() override { return 1; };
+
+  virtual void process(const Action *action) override;
+  
+private:
+  Controller * controller;
+  Configuration * modconfig;
+  Transport * transport;
+  bool isResetRequested = false;
+  char serialChar = '0';
+  
+  
+  void handleAction(const Action *action);
+  void processSerialInput();
+  void processSerialInputImpl(char c);
+  void indicateMode(VlcbModeParams i);
+  void getHelp();
+public:
+  void serialCallback(cmd *c);
+  void setupHelp();
+  char getFirstChar() const {return serialChar; }
+  
+};
+
+extern SimpleCLI simpleCli;
+//extern char local_serial_char;
+
+} // end namespace VLCB
+
+// Allow access to the instance in SimpleCLIUserInterface.cpp
+// Note that this is not in the VLCB namespace.
+extern VLCB::SimpleCLIUserInterface simpleCLIUserInterface;
+
+//using VLCB::cli;
+//extern VLCB::SimpleCLI cli;
+
+

--- a/src/SimpleCLIUserInterface.h
+++ b/src/SimpleCLIUserInterface.h
@@ -46,7 +46,6 @@ public:
 };
 
 extern SimpleCLI simpleCli;
-//extern char local_serial_char;
 
 } // end namespace VLCB
 
@@ -54,7 +53,5 @@ extern SimpleCLI simpleCli;
 // Note that this is not in the VLCB namespace.
 extern VLCB::SimpleCLIUserInterface simpleCLIUserInterface;
 
-//using VLCB::cli;
-//extern VLCB::SimpleCLI cli;
 
 


### PR DESCRIPTION
This adds a new version of the SerialUserInterface which allows for more use of the command line. It supports commands with arguments and can be used to build a help system.

I have provided an interface to the previous SerialUserInterface commands.

The example shows how users can add extra commands. This example runs on a MEGA 1280 or MEGA 2560. It is too large for a UNO or NANO.
