### PR TITLE
Refactorings to reduce code size

### DIFF
--- a/src/CanService.h
+++ b/src/CanService.h
@@ -22,7 +22,7 @@ public:
   CanService(CanTransport * tpt) : canTransport(tpt) {}
 
   virtual void setController(Controller *cntrl) override;
-  virtual byte getServiceID() override { return SERVICE_ID_CAN; }
+  virtual VlcbServiceTypes getServiceID() override { return SERVICE_ID_CAN; }
   virtual byte getServiceVersionID() override { return 1; }
 
   virtual void process(const Action * action) override;

--- a/src/ConsumeOwnEventsService.h
+++ b/src/ConsumeOwnEventsService.h
@@ -15,7 +15,7 @@ class Configuration;
 class ConsumeOwnEventsService : public Service
 {
 public:
-  virtual byte getServiceID() override
+  virtual VlcbServiceTypes getServiceID() override
   {
     return SERVICE_ID_CONSUME_OWN_EVENTS;
   }

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -123,7 +123,7 @@ void Controller::indicateMode(VlcbModeParams mode)
   setParamFlag(PF_NORMAL, mode == MODE_NORMAL);
 }
 
-void Controller::setParamFlag(unsigned char flag, bool set)
+void Controller::setParamFlag(VlcbParamFlags flag, bool set)
 { 
   if (set)
   {
@@ -170,7 +170,7 @@ bool Controller::sendMessage(const VlcbMessage *msg)
   return true;
 }
 
-bool Controller::sendMessageWithNNandData(int opc, int len, ...)
+bool Controller::sendMessageWithNNandData(VlcbOpCodes opc, int len, ...)
 {
   va_list args;
   va_start(args, len);
@@ -204,7 +204,7 @@ bool Controller::sendCMDERR(byte cerrno)
   return sendMessageWithNN(OPC_CMDERR, cerrno);
 }
 
-void Controller::sendGRSP(byte opCode, byte serviceType, byte errCode)
+void Controller::sendGRSP(VlcbOpCodes opCode, byte serviceType, byte errCode)
 {
   sendMessageWithNN(OPC_GRSP, opCode, serviceType, errCode);
 }

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -71,21 +71,21 @@ public:
   const ArrayHolder<Service *> & getServices() { return services; }
 
   void setParams(unsigned char *mparams);
-  void setParamFlag(unsigned char flag, bool b);
+  void setParamFlag(VlcbParamFlags flag, bool set);
   unsigned char getParam(unsigned int param) { return _mparams[param]; }
 
   bool sendMessage(const VlcbMessage *msg);
 
   void begin();
-  inline bool sendMessageWithNN(int opc);
-  inline bool sendMessageWithNN(int opc, byte b1);
-  inline bool sendMessageWithNN(int opc, byte b1, byte b2);
-  inline bool sendMessageWithNN(int opc, byte b1, byte b2, byte b3);
-  inline bool sendMessageWithNN(int opc, byte b1, byte b2, byte b3, byte b4);
-  inline bool sendMessageWithNN(int opc, byte b1, byte b2, byte b3, byte b4, byte b5);
+  inline bool sendMessageWithNN(VlcbOpCodes opc);
+  inline bool sendMessageWithNN(VlcbOpCodes opc, byte b1);
+  inline bool sendMessageWithNN(VlcbOpCodes opc, byte b1, byte b2);
+  inline bool sendMessageWithNN(VlcbOpCodes opc, byte b1, byte b2, byte b3);
+  inline bool sendMessageWithNN(VlcbOpCodes opc, byte b1, byte b2, byte b3, byte b4);
+  inline bool sendMessageWithNN(VlcbOpCodes opc, byte b1, byte b2, byte b3, byte b4, byte b5);
   bool sendWRACK();
   bool sendCMDERR(byte cerrno);
-  void sendGRSP(byte opCode, byte serviceType, byte errCode);
+  void sendGRSP(VlcbOpCodes opCode, byte serviceType, byte errCode);
 
   byte getModuleCANID() { return module_config->CANID; }
   void process();
@@ -106,36 +106,36 @@ private:
   
   CircularBuffer<Action> actionQueue;
 
-  bool sendMessageWithNNandData(int opc) { return sendMessageWithNNandData(opc, 0, 0); }
-  bool sendMessageWithNNandData(int opc, int len, ...);
+  bool sendMessageWithNNandData(VlcbOpCodes opc) { return sendMessageWithNNandData(opc, 0, 0); }
+  bool sendMessageWithNNandData(VlcbOpCodes opc, int len, ...);
 };
 
-bool Controller::sendMessageWithNN(int opc)
+bool Controller::sendMessageWithNN(VlcbOpCodes opc)
 {
   return sendMessageWithNNandData(opc);
 }
 
-bool Controller::sendMessageWithNN(int opc, byte b1)
+bool Controller::sendMessageWithNN(VlcbOpCodes opc, byte b1)
 {
   return sendMessageWithNNandData(opc, 1, b1);
 }
 
-bool Controller::sendMessageWithNN(int opc, byte b1, byte b2)
+bool Controller::sendMessageWithNN(VlcbOpCodes opc, byte b1, byte b2)
 {
   return sendMessageWithNNandData(opc, 2, b1, b2);
 }
 
-bool Controller::sendMessageWithNN(int opc, byte b1, byte b2, byte b3)
+bool Controller::sendMessageWithNN(VlcbOpCodes opc, byte b1, byte b2, byte b3)
 {
   return sendMessageWithNNandData(opc, 3, b1, b2, b3);
 }
 
-bool Controller::sendMessageWithNN(int opc, byte b1, byte b2, byte b3, byte b4)
+bool Controller::sendMessageWithNN(VlcbOpCodes opc, byte b1, byte b2, byte b3, byte b4)
 {
   return sendMessageWithNNandData(opc, 4, b1, b2, b3, b4);
 }
 
-bool Controller::sendMessageWithNN(int opc, byte b1, byte b2, byte b3, byte b4, byte b5)
+bool Controller::sendMessageWithNN(VlcbOpCodes opc, byte b1, byte b2, byte b3, byte b4, byte b5)
 {
   return sendMessageWithNNandData(opc, 5, b1, b2, b3, b4, b5);
 }

--- a/src/EventConsumerService.h
+++ b/src/EventConsumerService.h
@@ -20,7 +20,7 @@ public:
   void setEventHandler(void (*fptr)(byte index, const VlcbMessage *msg));
   virtual void process(const Action * action) override;
 
-  virtual byte getServiceID() override 
+  virtual VlcbServiceTypes getServiceID() override 
   {
     return SERVICE_ID_CONSUMER;
   }

--- a/src/EventProducerService.h
+++ b/src/EventProducerService.h
@@ -19,7 +19,7 @@ public:
   void setRequestEventHandler(void (*fptr)(byte index, const VlcbMessage *msg));
   virtual void process(const Action * action) override;
 
-  virtual byte getServiceID() override
+  virtual VlcbServiceTypes getServiceID() override
   {
     return SERVICE_ID_PRODUCER;
   }

--- a/src/EventTeachingService.h
+++ b/src/EventTeachingService.h
@@ -20,7 +20,7 @@ public:
   virtual void setController(Controller *cntrl) override;
   virtual void process(const Action * action) override;
 
-  virtual byte getServiceID() override { return SERVICE_ID_OLD_TEACH; }
+  virtual VlcbServiceTypes getServiceID() override { return SERVICE_ID_OLD_TEACH; }
   virtual byte getServiceVersionID() override { return 1; }
 
   void enableLearn();

--- a/src/LEDUserInterface.h
+++ b/src/LEDUserInterface.h
@@ -20,7 +20,7 @@ class LEDUserInterface : public Service
 public:
   LEDUserInterface(byte greenLedPin, byte yellowLedPin, byte pushButtonPin);
   virtual void setController(Controller *ctrl) override { this->controller = ctrl; }
-  virtual byte getServiceID() override { return 0; };
+  virtual VlcbServiceTypes getServiceID() override { return SERVICE_ID_HIDDEN; };
   virtual byte getServiceVersionID() override { return 1; };
 
   bool isButtonPressed();

--- a/src/LongMessageService.h
+++ b/src/LongMessageService.h
@@ -52,7 +52,7 @@ public:
   void setDelay(byte delay_in_millis);
   void setTimeout(unsigned int timeout_in_millis);
 
-  virtual byte getServiceID() override { return SERVICE_ID_STREAMING; }
+  virtual VlcbServiceTypes getServiceID() override { return SERVICE_ID_STREAMING; }
   virtual byte getServiceVersionID() override { return 1; }
 
 protected:

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -498,7 +498,7 @@ void MinimumNodeService::handleModeMessage(const VlcbMessage *msg, unsigned int 
 
     case MODE_HEARTBEAT_ON:
     case MODE_HEARTBEAT_OFF:
-      noHeartbeat = requestedMode == MODE_HEARTBEAT_OFF;
+      noHeartbeat = (requestedMode == MODE_HEARTBEAT_OFF);
       module_config->setHeartbeat(!noHeartbeat);
       break;
       

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -497,14 +497,8 @@ void MinimumNodeService::handleModeMessage(const VlcbMessage *msg, unsigned int 
       break;
 
     case MODE_HEARTBEAT_ON:
-      // Turn on Heartbeat
-      noHeartbeat = false;
-      module_config->setHeartbeat(!noHeartbeat);
-      break;
-
     case MODE_HEARTBEAT_OFF:
-      // Turn off Heartbeat
-      noHeartbeat = true;
+      noHeartbeat = requestedMode == MODE_HEARTBEAT_OFF;
       module_config->setHeartbeat(!noHeartbeat);
       break;
       

--- a/src/MinimumNodeService.h
+++ b/src/MinimumNodeService.h
@@ -22,7 +22,7 @@ public:
   virtual void setController(Controller *cntrl) override;
   virtual void process(const Action *action) override; 
 
-  virtual byte getServiceID() override { return SERVICE_ID_MNS; }
+  virtual VlcbServiceTypes getServiceID() override { return SERVICE_ID_MNS; }
   virtual byte getServiceVersionID() override { return 1; }
   
   virtual void begin() override;

--- a/src/NodeVariableService.h
+++ b/src/NodeVariableService.h
@@ -20,7 +20,7 @@ class NodeVariableService : public Service
 public:
 
   virtual void setController(Controller *cntrl) override;
-  virtual byte getServiceID() override { return SERVICE_ID_NV; }
+  virtual VlcbServiceTypes getServiceID() override { return SERVICE_ID_NV; }
   virtual byte getServiceVersionID() override { return 1; }
   virtual void process(const Action * action) override;
 

--- a/src/SerialUserInterface.h
+++ b/src/SerialUserInterface.h
@@ -17,7 +17,7 @@ class SerialUserInterface : public Service
 public:
   SerialUserInterface(Transport *transport);
   virtual void setController(Controller *ctrl) override;
-  virtual byte getServiceID() override { return 0; };
+  virtual VlcbServiceTypes getServiceID() override { return SERVICE_ID_HIDDEN; };
   virtual byte getServiceVersionID() override { return 1; };
 
   virtual void process(const Action *action) override;

--- a/src/Service.h
+++ b/src/Service.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include <vlcbdefs.hpp>
 
 namespace VLCB
 {
@@ -18,7 +19,7 @@ class Service
 public:
   virtual void setController(Controller * /*controller*/) {}
   virtual void begin() {}
-  virtual byte getServiceID() = 0;
+  virtual VlcbServiceTypes getServiceID() = 0;
   virtual byte getServiceVersionID() = 0;
 
   virtual void process(const Action * action) = 0;

--- a/src/vlcbdefs.hpp
+++ b/src/vlcbdefs.hpp
@@ -488,6 +488,7 @@ enum VlcbServiceTypes : unsigned char
   // 
   // VLCB Service Types
   // 
+  SERVICE_ID_HIDDEN = 0, // Pseudo services that shall not be exposed externally.
   SERVICE_ID_MNS = 1, // The minimum node service. All modules must implement this.
   SERVICE_ID_NV = 2, // The NV service.
   SERVICE_ID_CAN = 3, // CAN service. Deals with CANID enumeration.

--- a/test/MockTransportService.h
+++ b/test/MockTransportService.h
@@ -21,7 +21,7 @@ class MockTransportService : public VLCB::Service
 public:
   virtual void setController(VLCB::Controller *cntrl) override;
 
-  virtual byte getServiceID() override { return 99; }
+  virtual VlcbServiceTypes getServiceID() override { return SERVICE_ID_CAN; }
   virtual byte getServiceVersionID() override { return 1; }
 
   virtual void process(const VLCB::Action * action) override;

--- a/test/MockUserInterface.h
+++ b/test/MockUserInterface.h
@@ -15,7 +15,7 @@ class MockUserInterface : public VLCB::Service
 {
 public:
   virtual void process(const VLCB::Action *action) override;
-  virtual byte getServiceID() override { return 0; };
+  virtual VlcbServiceTypes getServiceID() override { return SERVICE_ID_HIDDEN; };
   virtual byte getServiceVersionID() override { return 1; };
   
   VlcbModeParams getIndicatedMode();


### PR DESCRIPTION
Two refactorings that reduce code size a little.
* Change types from builtin types to the enum types defined in vlcbdefs.hpp. Some of these types are smaller than the "int" used earlier.
* Handling mode command for setting heartbeat on/off deduplicated.