### PR TITLE
Fix tests for mns

### DIFF
--- a/src/LEDUserInterface.cpp
+++ b/src/LEDUserInterface.cpp
@@ -112,7 +112,7 @@ void LEDUserInterface::checkRequestedAction()
       unsigned long press_time = pushButton.getLastStateDuration();
       //Serial << F("  button released, pressed for ") << pushButton.getLastStateDuration() << endl; Serial.flush();
 
-      // long hold > 6 secs
+      // long hold > 4 secs
       if (press_time > SW_TR_HOLD)
       {
         //Serial << F("  long press - change mode") << endl;

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -473,7 +473,6 @@ void MinimumNodeService::handleModeMessage(const VlcbMessage *msg, unsigned int 
           break;
       
         default:
-          controller->sendGRSP(OPC_MODE, getServiceID(), CMDERR_INV_CMD);
           break;
       }
       break;

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -480,26 +480,36 @@ void MinimumNodeService::handleModeMessage(const VlcbMessage *msg, unsigned int 
 
     case MODE_SETUP:
       // Request Setup
-      if (instantMode == MODE_NORMAL)
+      switch (instantMode)
       {
-        controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_OK);
-        initSetupFromNormal();
-      }
-      else
-      {
-        controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_INVALID_MODE);
+        case MODE_NORMAL:
+          controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_OK);
+          initSetupFromNormal();
+          break;
+
+        case MODE_SETUP:
+          controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_INVALID_MODE);
+          break;
+
+        default:
+          break;
       }
       break;
       
     case MODE_NORMAL:
       // Request Normal. Only OK if we are already in Normal mode.
-      if (instantMode == MODE_NORMAL)
+      switch (instantMode)
       {
-        controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_OK);
-      }
-      else
-      {
-        controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_INVALID_MODE);
+        case MODE_NORMAL:
+          controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_OK);
+          break;
+
+        case MODE_SETUP:
+          controller->sendGRSP(OPC_MODE, getServiceID(), GRSP_INVALID_MODE);
+          break;
+
+        default:
+          break;
       }
       break;
 

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -59,7 +59,10 @@ void MinimumNodeService::setUninitialised()
   // DEBUG_SERIAL << F("> set Uninitialised") << endl;
   requestingNewNN = false;
   instantMode = MODE_UNINITIALISED;
-  controller->sendMessageWithNN(OPC_NNREL);  // release node number first
+  if (controller->getModuleConfig()->nodeNum != 0)
+  {
+    controller->sendMessageWithNN(OPC_NNREL);  // release node number first
+  }
   controller->getModuleConfig()->setModuleUninitializedMode();
   controller->getModuleConfig()->setCANID(0);
 

--- a/test/VlcbCommon.cpp
+++ b/test/VlcbCommon.cpp
@@ -36,14 +36,21 @@ VLCB::Configuration * createConfiguration(VLCB::Storage * mockStorage)
 
 VLCB::Controller createController(const std::initializer_list<VLCB::Service *> services)
 {
+  return createController(MODE_NORMAL, services);
+}
+
+VLCB::Controller createController(VlcbModeParams startupMode, const std::initializer_list<VLCB::Service *> services)
+{
   // Use pointers to objects to create the controller with.
   // Use unique_ptr so that next invocation deletes the previous objects.
 
   configuration.reset(createConfiguration());
 
   VLCB::Controller controller(configuration.get(), services);
-
-  configuration->setModuleNormalMode(0x0104);
+  if (startupMode == MODE_NORMAL)
+  {
+    configuration->setModuleNormalMode(0x0104);
+  }
   static std::unique_ptr<VLCB::Parameters> params;
   params.reset(new VLCB::Parameters(*configuration));
   params->setVersion(1, 1, 'a');

--- a/test/VlcbCommon.h
+++ b/test/VlcbCommon.h
@@ -26,6 +26,7 @@ VLCB::Configuration * createConfiguration();
 VLCB::Configuration * createConfiguration(VLCB::Storage * mockStorage);
 // Use MockTransport to mock out the whole transport part.
 VLCB::Controller createController(std::initializer_list<VLCB::Service *> services);
+VLCB::Controller createController(VlcbModeParams startupMode, std::initializer_list<VLCB::Service *> services);
 // Use a provided transport.
 VLCB::Controller createController(VLCB::Transport * trp, std::initializer_list<VLCB::Service *> services);
 

--- a/test/testCanService.cpp
+++ b/test/testCanService.cpp
@@ -24,7 +24,7 @@ std::unique_ptr<VLCB::MinimumNodeServiceWithDiagnostics> minimumNodeService;
 // Use MockCanTransport to test CanTransport class.
 std::unique_ptr<MockCanTransport> mockCanTransport;
 
-VLCB::Controller createController()
+VLCB::Controller createController(VlcbModeParams startupMode = MODE_NORMAL)
 {
   minimumNodeService.reset(new VLCB::MinimumNodeServiceWithDiagnostics);
 
@@ -33,7 +33,7 @@ VLCB::Controller createController()
   static std::unique_ptr<VLCB::CanServiceWithDiagnostics> canService;
   canService.reset(new VLCB::CanServiceWithDiagnostics(mockCanTransport.get()));
 
-  VLCB::Controller controller = ::createController({minimumNodeService.get(), canService.get()});
+  VLCB::Controller controller = ::createController(startupMode, {minimumNodeService.get(), canService.get()});
   controller.begin();
 
   return controller;
@@ -90,8 +90,7 @@ void testCanidEnumerationOnUserAction()
 {
   test();
 
-  VLCB::Controller controller = createController();
-  minimumNodeService->setUninitialised(); // Clear all state as if module is factory fresh.
+  VLCB::Controller controller = createController(MODE_UNINITIALISED);
   minimumNodeService->setSetupMode();
 
   // Check that CANID is unset on creation.
@@ -121,8 +120,7 @@ void testCanidEnumerationOnSetUp()
 {
   test();
 
-  VLCB::Controller controller = createController();
-  minimumNodeService->setUninitialised(); // Clear all state as if module is factory fresh.
+  VLCB::Controller controller = createController(MODE_UNINITIALISED);
 
   // Check that CANID is unset on creation.
   assertEquals(0, controller.getModuleCANID());
@@ -235,8 +233,7 @@ void testFindFreeCanidOnPopulatedBus()
 {
   test();
 
-  VLCB::Controller controller = createController();
-  minimumNodeService->setUninitialised(); // Clear all state as if module is factory fresh.
+  VLCB::Controller controller = createController(MODE_UNINITIALISED);
   minimumNodeService->setSetupMode();
 
   // Check that CANID is unset on creation.

--- a/test/testEventProducerService.cpp
+++ b/test/testEventProducerService.cpp
@@ -20,7 +20,7 @@ std::unique_ptr<VLCB::MinimumNodeService> minimumNodeService;
 std::unique_ptr<VLCB::EventProducerService> eventProducerService;
 static std::unique_ptr<MockTransportService> mockTransportService;
 
-VLCB::Controller createController()
+VLCB::Controller createController(VlcbModeParams startupMode = MODE_NORMAL)
 {
   minimumNodeService.reset(new VLCB::MinimumNodeService);
 
@@ -28,7 +28,7 @@ VLCB::Controller createController()
 
   eventProducerService.reset(new VLCB::EventProducerService);
 
-  VLCB::Controller controller = ::createController({minimumNodeService.get(), eventProducerService.get(), mockTransportService.get()});
+  VLCB::Controller controller = ::createController(startupMode, {minimumNodeService.get(), eventProducerService.get(), mockTransportService.get()});
   controller.begin();
 
   return controller;
@@ -193,10 +193,7 @@ void testSetProducedDefaultEventsOnNewBoard()
 {
   test();
 
-  VLCB::Controller controller = createController();
-
-  // Set module into Uninitialized mode to get unitialized memory.
-  minimumNodeService->setUninitialised();
+  VLCB::Controller controller = createController(MODE_UNINITIALISED);
 
   controller.begin();
 

--- a/test/testMinimumNodeService.cpp
+++ b/test/testMinimumNodeService.cpp
@@ -1060,7 +1060,7 @@ void testModeUninitializedToSetup()
   assertEquals(0, mockTransportService->sent_messages.size());
 }
 
-void testModeUninitializedToOtherThanSetup()
+void testModeUninitializedToNormal()
 {
   test();
 
@@ -1074,7 +1074,21 @@ void testModeUninitializedToOtherThanSetup()
   assertEquals(0, mockTransportService->sent_messages.size());
 }
 
-void testModeSetupToOtherThanNormal()
+void testModeUninitializedToUninitialized()
+{
+  test();
+
+  VLCB::Controller controller = createController(MODE_UNINITIALISED);
+
+  VLCB::VlcbMessage msg_rqsd = {4, {OPC_MODE, 0, 0, MODE_UNINITIALISED}};
+  mockTransportService->setNextMessage(msg_rqsd);
+
+  process(controller);
+
+  assertEquals(0, mockTransportService->sent_messages.size());
+}
+
+void testModeSetupToSetup()
 {
   test();
 
@@ -1176,8 +1190,9 @@ void testMinimumNodeService()
   testModeSetupToUnininitialized();
   testModeNormalToSetup();
   testModeUninitializedToSetup();
-  testModeUninitializedToOtherThanSetup();
-  testModeSetupToOtherThanNormal();
+  testModeUninitializedToNormal();
+  testModeUninitializedToUninitialized();
+  testModeSetupToSetup();
   testModeNormalToNormal();
   testModeShortMessage();
 }

--- a/test/testMinimumNodeService.cpp
+++ b/test/testMinimumNodeService.cpp
@@ -946,7 +946,7 @@ void testRequestMnsDiagnosticsNodeNumberChanges()
   assertEquals(1, mockTransportService->sent_messages[0].data[6]);
 }
 
-void testModeSetupToNormal()
+void testModeSetupFromUninitializedToNormal()
 {
   test();
 
@@ -967,6 +967,29 @@ void testModeSetupToNormal()
   assertEquals(MODE_UNINITIALISED, mockUserInterface->getIndicatedMode());
   assertEquals(MODE_UNINITIALISED, configuration->currentMode);
   assertEquals(0, configuration->nodeNum);
+}
+
+void testModeSetupFromNormalToNormal()
+{
+  test();
+
+  VLCB::Controller controller = createController(MODE_NORMAL);
+  minimumNodeService->setSetupMode();
+
+  VLCB::VlcbMessage msg_rqsd = {4, {OPC_MODE, 0x01, 0x04, MODE_NORMAL}};
+  mockTransportService->setNextMessage(msg_rqsd);
+
+  process(controller);
+
+  assertEquals(1, mockTransportService->sent_messages.size());
+  assertEquals(OPC_GRSP, mockTransportService->sent_messages[0].data[0]);
+  assertEquals(OPC_MODE, mockTransportService->sent_messages[0].data[3]);
+  assertEquals(SERVICE_ID_MNS, mockTransportService->sent_messages[0].data[4]);
+  assertEquals(GRSP_INVALID_MODE, mockTransportService->sent_messages[0].data[5]);
+
+  assertEquals(MODE_NORMAL, mockUserInterface->getIndicatedMode());
+  assertEquals(MODE_NORMAL, configuration->currentMode);
+  assertEquals(0x104, configuration->nodeNum);
 }
 
 void testModeSetupToUnininitialized()
@@ -1034,12 +1057,7 @@ void testModeUninitializedToSetup()
 
   process(controller);
 
-  // TODO Question: Should the node respond to this?
-  assertEquals(1, mockTransportService->sent_messages.size());
-  assertEquals(OPC_GRSP, mockTransportService->sent_messages[0].data[0]);
-  assertEquals(OPC_MODE, mockTransportService->sent_messages[0].data[3]);
-  assertEquals(SERVICE_ID_MNS, mockTransportService->sent_messages[0].data[4]);
-  assertEquals(GRSP_INVALID_MODE, mockTransportService->sent_messages[0].data[5]);
+  assertEquals(0, mockTransportService->sent_messages.size());
 }
 
 void testModeUninitializedToOtherThanSetup()
@@ -1053,12 +1071,7 @@ void testModeUninitializedToOtherThanSetup()
 
   process(controller);
 
-  // TODO Question: Should the node respond to this?
-  assertEquals(1, mockTransportService->sent_messages.size());
-  assertEquals(OPC_GRSP, mockTransportService->sent_messages[0].data[0]);
-  assertEquals(OPC_MODE, mockTransportService->sent_messages[0].data[3]);
-  assertEquals(SERVICE_ID_MNS, mockTransportService->sent_messages[0].data[4]);
-  assertEquals(GRSP_INVALID_MODE, mockTransportService->sent_messages[0].data[5]);
+  assertEquals(0, mockTransportService->sent_messages.size());
 }
 
 void testModeSetupToOtherThanNormal()
@@ -1158,7 +1171,8 @@ void testMinimumNodeService()
   testRequestAllDiagnosticsAllServices();
   testRequestMnsDiagnosticsUptime();
   testRequestMnsDiagnosticsNodeNumberChanges();
-  testModeSetupToNormal();
+  testModeSetupFromUninitializedToNormal();
+  testModeSetupFromNormalToNormal();
   testModeSetupToUnininitialized();
   testModeNormalToSetup();
   testModeUninitializedToSetup();


### PR DESCRIPTION
Update unit tests to reflect changes to mode changes in the MNS specification.
This resulted in a few changes in the MNS implementation.