### PR TITLE
Omit NNREL when not needed.

### DIFF
--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -77,8 +77,6 @@ void MinimumNodeService::initSetupFromNormal()
 {
   // DEBUG_SERIAL << F("> reverting to Setup mode") << endl;
   requestingNewNN = true;
-  controller->sendMessageWithNN(OPC_NNREL);
-  // DEBUG_SERIAL << F("> initiating Normal negotation") << endl;
 
   initSetupCommon();
 }

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -48,7 +48,6 @@ void MinimumNodeService::initSetupCommon()
 void MinimumNodeService::setNormal(unsigned int nn)
 {
   // DEBUG_SERIAL << F("> set Normal") << endl;
-  requestingNewNN = false;
   instantMode = MODE_NORMAL;
   controller->getModuleConfig()->setModuleNormalMode(nn);
   controller->indicateMode(MODE_NORMAL);
@@ -64,7 +63,6 @@ void MinimumNodeService::setUninitialised()
   {
     controller->sendMessageWithNN(OPC_NNREL);  // release node number first
   }
-  requestingNewNN = false;
   instantMode = MODE_UNINITIALISED;
   controller->getModuleConfig()->setModuleUninitializedMode();
   controller->indicateMode(MODE_UNINITIALISED);
@@ -76,8 +74,6 @@ void MinimumNodeService::setUninitialised()
 void MinimumNodeService::initSetupFromNormal()
 {
   // DEBUG_SERIAL << F("> reverting to Setup mode") << endl;
-  requestingNewNN = true;
-
   initSetupCommon();
 }
 
@@ -132,10 +128,9 @@ void MinimumNodeService::process(const Action *action)
           instantMode = controller->getModuleConfig()->currentMode;
           controller->indicateMode(instantMode);
 
-          if (requestingNewNN)
+          if (controller->getModuleConfig()->nodeNum != 0)
           {
             // Revert to previous NN   
-            requestingNewNN = false;
             controller->sendMessageWithNN(OPC_NNACK);
           }
             

--- a/src/MinimumNodeService.h
+++ b/src/MinimumNodeService.h
@@ -34,7 +34,6 @@ public:
 
 private:
 
-  bool requestingNewNN = false;
   VlcbModeParams instantMode;
   
   void initSetupFromUninitialised();

--- a/test/testMinimumNodeService.cpp
+++ b/test/testMinimumNodeService.cpp
@@ -92,13 +92,10 @@ void testNormalRequestNodeNumber()
 
   process(controller);
 
-  assertEquals(2, mockTransportService->sent_messages.size());
-  assertEquals(OPC_NNREL, mockTransportService->sent_messages[0].data[0]);
+  assertEquals(1, mockTransportService->sent_messages.size());
+  assertEquals(OPC_RQNN, mockTransportService->sent_messages[0].data[0]);
   assertEquals(0x01, mockTransportService->sent_messages[0].data[1]);
   assertEquals(0x04, mockTransportService->sent_messages[0].data[2]);
-  assertEquals(OPC_RQNN, mockTransportService->sent_messages[1].data[0]);
-  assertEquals(0x01, mockTransportService->sent_messages[1].data[1]);
-  assertEquals(0x04, mockTransportService->sent_messages[1].data[2]);
 
   assertEquals(MODE_SETUP, mockUserInterface->getIndicatedMode());
   assertEquals(MODE_NORMAL, configuration->currentMode);
@@ -126,32 +123,6 @@ void testNormalChangeModeToUninitialized()
   assertEquals(MODE_UNINITIALISED, mockUserInterface->getIndicatedMode());
   assertEquals(MODE_UNINITIALISED, configuration->currentMode);
   assertEquals(0x0, configuration->nodeNum);
-}
-
-void testNormalChangeModeToSetup()
-{
-  test();
-
-  VLCB::Controller controller = createController();
-
-  // User requests to enter Setup mode.
-  controller.putAction({VLCB::ACT_RENEGOTIATE});
-
-  process(controller);
-
-  assertEquals(2, mockTransportService->sent_messages.size());
-  assertEquals(OPC_NNREL, mockTransportService->sent_messages[0].data[0]);
-  assertEquals(0x01, mockTransportService->sent_messages[0].data[1]);
-  assertEquals(0x04, mockTransportService->sent_messages[0].data[2]);
-  assertEquals(OPC_RQNN, mockTransportService->sent_messages[1].data[0]);
-  assertEquals(0x01, mockTransportService->sent_messages[1].data[1]);
-  assertEquals(0x04, mockTransportService->sent_messages[1].data[2]);
-
-  assertEquals(MODE_SETUP, mockUserInterface->getIndicatedMode());
-  assertEquals(MODE_NORMAL, configuration->currentMode);
-
-  // Module will hold on to node number in case setup times out.
-  assertEquals(0x104, configuration->nodeNum);
 }
 
 void testSetupFromUninitializedReceiveRequestNodeNumberElsewhere()
@@ -956,20 +927,16 @@ void testModeNormalToSetup()
 
   process(controller);
 
-  assertEquals(3, mockTransportService->sent_messages.size());
+  assertEquals(2, mockTransportService->sent_messages.size());
   assertEquals(OPC_GRSP, mockTransportService->sent_messages[0].data[0]);
   assertEquals(OPC_MODE, mockTransportService->sent_messages[0].data[3]);
   assertEquals(SERVICE_ID_MNS, mockTransportService->sent_messages[0].data[4]);
   assertEquals(GRSP_OK, mockTransportService->sent_messages[0].data[5]);
   // NN should be 0.
 
-  assertEquals(OPC_NNREL, mockTransportService->sent_messages[1].data[0]);
+  assertEquals(OPC_RQNN, mockTransportService->sent_messages[1].data[0]);
   assertEquals(0x01, mockTransportService->sent_messages[1].data[1]);
   assertEquals(0x04, mockTransportService->sent_messages[1].data[2]);
-
-  assertEquals(OPC_RQNN, mockTransportService->sent_messages[2].data[0]);
-  assertEquals(0x01, mockTransportService->sent_messages[2].data[1]);
-  assertEquals(0x04, mockTransportService->sent_messages[2].data[2]);
 
   assertEquals(MODE_SETUP, mockUserInterface->getIndicatedMode());
   assertEquals(MODE_NORMAL, configuration->currentMode);
@@ -1081,7 +1048,6 @@ void testMinimumNodeService()
   testUninitializedRequestNodeNumber();
   testNormalRequestNodeNumber();
   testNormalChangeModeToUninitialized();
-  testNormalChangeModeToSetup();
   testSetupFromUninitializedReceiveRequestNodeNumberElsewhere();
   testSetupFromNormalReceiveRequestNodeNumberElsewhere();
   testSetupFromUninitializedAbort();

--- a/test/testMinimumNodeService.cpp
+++ b/test/testMinimumNodeService.cpp
@@ -195,9 +195,11 @@ void testSetupFromNormalAbort()
 
   process(controller);
 
-  // Expect module to not respond, but to change to non-setup mode.
-  // TODO Question: Shouldn't this reclaim NN with NNACK?
-  assertEquals(0, mockTransportService->sent_messages.size());
+  // Expect module to revert back to NORMAL and reclaim its node number.
+  assertEquals(1, mockTransportService->sent_messages.size());
+  assertEquals(OPC_NNACK, mockTransportService->sent_messages[0].data[0]);
+  assertEquals(0x01, mockTransportService->sent_messages[0].data[1]);
+  assertEquals(0x04, mockTransportService->sent_messages[0].data[2]);
 
   // TODO: Need a better way of determining the instantMode.
   assertEquals(MODE_NORMAL, mockUserInterface->getIndicatedMode());


### PR DESCRIPTION
This is a followup of pull request #133 but with a debated commit omitted.

Commits:
* No need for NNREL when requesting a new NN. RQNN is enough.
* Fix reclaiming of NN on abort from Setup.