### PR TITLE
Don't release NodeNumber when transitioning Setup->Uninitialized.

### DIFF
--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -59,7 +59,7 @@ void MinimumNodeService::setNormal(unsigned int nn)
 void MinimumNodeService::setUninitialised()
 {
   // DEBUG_SERIAL << F("> set Uninitialised") << endl;
-  if (controller->getModuleConfig()->nodeNum != 0  && controller->getModuleConfig()->currentMode == MODE_NORMAL)
+  if (controller->getModuleConfig()->nodeNum != 0  && instantMode == MODE_NORMAL)
   {
     controller->sendMessageWithNN(OPC_NNREL);  // release node number first
   }


### PR DESCRIPTION
Sorry, I was wrong about how to check the state in setUninitialized(). 
If we are in Setup(from Normal) then currentState == NORMAL. We need to check for SETUP which can only be done with instantMode.
Added missing test cases for this transition.