### PR TITLE
Improve diagnostics code

### DIFF
--- a/src/CanServiceWithDiagnostics.cpp
+++ b/src/CanServiceWithDiagnostics.cpp
@@ -12,70 +12,51 @@ namespace VLCB
 
 void CanServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, byte diagnosticsCode)
 {
+  unsigned int diagnosticsValue;
   switch (diagnosticsCode)
   {
     case 0x00:
       reportAllDiagnostics(serviceIndex);
-      break;
+      return;
     case 0x01: // CAN RX error counter
-      controller->sendDGN(serviceIndex, diagnosticsCode, canTransport->receiveErrorCounter());
+      diagnosticsValue = canTransport->receiveErrorCounter();
       break;
     case 0x02: // CAN TX error counter
-      controller->sendDGN(serviceIndex, diagnosticsCode, canTransport->transmitErrorCounter());
+      diagnosticsValue = canTransport->transmitErrorCounter();
       break;
     case 0x03: // CAN status byte, this is hardware dependent. The meaning of each bitfield must be documented.
-      controller->sendDGN(serviceIndex, diagnosticsCode, canTransport->errorStatus());
-      break;
-    case 0x04: // Tx buffer current usage count
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
-      break;
-    case 0x05: // Tx buffer overrun count
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
+      diagnosticsValue = canTransport->errorStatus();
       break;
     case 0x06: // TX message count
-      controller->sendDGN(serviceIndex, diagnosticsCode, canTransport->transmitCounter());
-      break;
-    case 0x07: // RX buffer current usage count
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
-      break;
-    case 0x08: // RX buffer overrun count
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
+      diagnosticsValue = canTransport->transmitCounter();
       break;
     case 0x09: // RX message counter
-      controller->sendDGN(serviceIndex, diagnosticsCode, canTransport->receiveCounter());
+      diagnosticsValue = canTransport->receiveCounter();
       break;
+
+    // Diagnostics codes not yet implemented
+    case 0x04: // Tx buffer current usage count
+    case 0x05: // Tx buffer overrun count
+    case 0x07: // RX buffer current usage count
+    case 0x08: // RX buffer overrun count
     case 0x0A: // CAN error frames detected
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
-      break;
     case 0x0B: // CAN error frames generated (both active and passive ?)
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
-      break;
     case 0x0C: // number of times CAN arbitration was lost
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
-      break;
     case 0x0D: // number of CANID enumerations
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
-      break;
     case 0x0E: // number of CANID conflicts detected
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
-      break;
     case 0x0F: // the number of CANID changes
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
-      break;
     case 0x10: // the number of CANID enumeration failures
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
-      break;
     case 0x11: // Transmit buffers used high watermark - Added in service version 2
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
-      break;
     case 0x12: // Receive buffers used high watermark - Added in service version 2
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
+      diagnosticsValue = 0;
       break;
 
     default:
       controller->sendGRSP(OPC_RDGN, serviceIndex, GRSP_INVALID_DIAGNOSTIC);
       return;
   }
+
+  controller->sendDGN(serviceIndex, diagnosticsCode, diagnosticsValue);
 }
 
 void CanServiceWithDiagnostics::reportAllDiagnostics(byte serviceIndex)

--- a/src/CanServiceWithDiagnostics.cpp
+++ b/src/CanServiceWithDiagnostics.cpp
@@ -18,63 +18,58 @@ void CanServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, byte diagno
       reportAllDiagnostics(serviceIndex);
       break;
     case 0x01: // CAN RX error counter
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode,
-                                    highByte(canTransport->receiveErrorCounter()), lowByte(canTransport->receiveErrorCounter()));
+      controller->sendDGN(serviceIndex, diagnosticsCode, canTransport->receiveErrorCounter());
       break;
     case 0x02: // CAN TX error counter
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode,
-                                    highByte(canTransport->transmitErrorCounter()), lowByte(canTransport->transmitErrorCounter()));
+      controller->sendDGN(serviceIndex, diagnosticsCode, canTransport->transmitErrorCounter());
       break;
     case 0x03: // CAN status byte, this is hardware dependent. The meaning of each bitfield must be documented.
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode,
-                                    highByte(canTransport->errorStatus()), lowByte(canTransport->errorStatus()));
+      controller->sendDGN(serviceIndex, diagnosticsCode, canTransport->errorStatus());
       break;
     case 0x04: // Tx buffer current usage count
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x05: // Tx buffer overrun count
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x06: // TX message count
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode,
-                                    highByte(canTransport->transmitCounter()), lowByte(canTransport->transmitCounter()));
+      controller->sendDGN(serviceIndex, diagnosticsCode, canTransport->transmitCounter());
       break;
     case 0x07: // RX buffer current usage count
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x08: // RX buffer overrun count
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x09: // RX message counter
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode,
-                                    highByte(canTransport->receiveCounter()), lowByte(canTransport->receiveCounter()));
+      controller->sendDGN(serviceIndex, diagnosticsCode, canTransport->receiveCounter());
       break;
     case 0x0A: // CAN error frames detected
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x0B: // CAN error frames generated (both active and passive ?)
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x0C: // number of times CAN arbitration was lost
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x0D: // number of CANID enumerations
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x0E: // number of CANID conflicts detected
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x0F: // the number of CANID changes
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x10: // the number of CANID enumeration failures
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x11: // Transmit buffers used high watermark - Added in service version 2
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x12: // Receive buffers used high watermark - Added in service version 2
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
 
     default:
@@ -86,7 +81,7 @@ void CanServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, byte diagno
 void CanServiceWithDiagnostics::reportAllDiagnostics(byte serviceIndex)
 {
   byte diagCount = 18;
-  controller->sendMessageWithNN(OPC_DGN, serviceIndex, 0, 0, diagCount);
+  controller->sendDGN(serviceIndex, 0, diagCount);
   for (byte i = 1; i <= diagCount ; ++i)
   {
     reportDiagnostics(serviceIndex, i);

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -211,6 +211,11 @@ void Controller::sendGRSP(VlcbOpCodes opCode, byte serviceType, byte errCode)
   sendMessageWithNN(OPC_GRSP, opCode, serviceType, errCode);
 }
 
+void Controller::sendDGN(byte serviceIndex, byte diagCode, unsigned int counter)
+{
+  sendMessageWithNN(OPC_DGN, serviceIndex, diagCode, highByte(counter), lowByte(counter));
+}
+
 void Controller::putAction(const Action &action)
 {
   // Serial << F("C>put action with type=") << action.actionType << endl;

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -90,6 +90,7 @@ public:
   bool sendWRACK();
   bool sendCMDERR(byte cerrno);
   void sendGRSP(VlcbOpCodes opCode, byte serviceType, byte errCode);
+  void sendDGN(byte serviceIndex, byte diagCode, unsigned int counter);
 
   byte getModuleCANID() const { return module_config->CANID; }
   void process();

--- a/src/EventConsumerServiceWithDiagnostics.cpp
+++ b/src/EventConsumerServiceWithDiagnostics.cpp
@@ -16,7 +16,7 @@ void EventConsumerServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, b
       reportAllDiagnostics(serviceIndex);
       break;
     case 0x01: 
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, highByte(diagEventsConsumed), lowByte(diagEventsConsumed));
+      controller->sendDGN(serviceIndex, diagnosticsCode, diagEventsConsumed);
       break;
     default:
       controller->sendGRSP(OPC_RDGN, serviceIndex, GRSP_INVALID_DIAGNOSTIC);
@@ -27,7 +27,7 @@ void EventConsumerServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, b
 void EventConsumerServiceWithDiagnostics::reportAllDiagnostics(byte serviceIndex)
 {
   byte diagCount = 1;
-  controller->sendMessageWithNN(OPC_DGN, serviceIndex, 0, 0, diagCount);
+  controller->sendDGN(serviceIndex, 0, diagCount);
   for (byte i = 1; i <= diagCount ; ++i)
   {
     reportDiagnostics(serviceIndex, i);

--- a/src/EventProducerServiceWithDiagnostics.cpp
+++ b/src/EventProducerServiceWithDiagnostics.cpp
@@ -16,7 +16,7 @@ void EventProducerServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, b
       reportAllDiagnostics(serviceIndex);
       break;
     case 0x01: 
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, highByte(diagEventsProduced), lowByte(diagEventsProduced));
+      controller->sendDGN(serviceIndex, diagnosticsCode, diagEventsProduced);
       break;
     default:
       controller->sendGRSP(OPC_RDGN, serviceIndex, GRSP_INVALID_DIAGNOSTIC);
@@ -27,7 +27,7 @@ void EventProducerServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, b
 void EventProducerServiceWithDiagnostics::reportAllDiagnostics(byte serviceIndex)
 {
   byte diagCount = 1;
-  controller->sendMessageWithNN(OPC_DGN, serviceIndex, 0, 0, diagCount);
+  controller->sendDGN(serviceIndex, 0, diagCount);
   for (byte i = 1; i <= diagCount ; ++i)
   {
     reportDiagnostics(serviceIndex, i);

--- a/src/EventTeachingServiceWithDiagnostics.cpp
+++ b/src/EventTeachingServiceWithDiagnostics.cpp
@@ -16,7 +16,7 @@ void EventTeachingServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, b
       reportAllDiagnostics(serviceIndex);
       break;
     case 0x01: 
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, highByte(diagEventsTaught), lowByte(diagEventsTaught));
+      controller->sendDGN(serviceIndex, diagnosticsCode, diagEventsTaught);
       break;
     default:
       controller->sendGRSP(OPC_RDGN, serviceIndex, GRSP_INVALID_DIAGNOSTIC);
@@ -27,7 +27,7 @@ void EventTeachingServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, b
 void EventTeachingServiceWithDiagnostics::reportAllDiagnostics(byte serviceIndex)
 {
   byte diagCount = 1;
-  controller->sendMessageWithNN(OPC_DGN, serviceIndex, 0, 0, diagCount);
+  controller->sendDGN( serviceIndex, 0, diagCount);
   for (byte i = 1; i <= diagCount ; ++i)
   {
     reportDiagnostics(serviceIndex, i);

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -352,7 +352,7 @@ void MinimumNodeService::handleSetNodeNumber(const VlcbMessage *msg, unsigned in
   controller->sendMessageWithNN(OPC_NNACK);
   // DEBUG_SERIAL << F("> sent NNACK for NN = ") << controller->getModuleConfig()->nodeNum << endl;
   
-  ++diagNodeNumberChanges;
+  diagNodeNumberChanged();
   controller->messageActedOn();
 }
 

--- a/src/MinimumNodeService.h
+++ b/src/MinimumNodeService.h
@@ -54,7 +54,8 @@ private:
   
 protected:
   virtual void handleMessage(const VlcbMessage *msg);
-  unsigned int diagNodeNumberChanges = 0;
+  
+  virtual void diagNodeNumberChanged() {};
 };
 
 }

--- a/src/MinimumNodeServiceWithDiagnostics.cpp
+++ b/src/MinimumNodeServiceWithDiagnostics.cpp
@@ -94,32 +94,23 @@ void MinimumNodeServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, byt
       reportAllDiagnostics(serviceIndex);
       break;
     case 0x01: // Status code -- TODO: not implemented, always good
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x02: // Uptime upper word
-    {
-      unsigned long now = millis() / 1000;
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, (now >> 24) & 0xFF , (now >> 16) & 0xFF);
+      controller->sendDGN(serviceIndex, diagnosticsCode, ((millis() / 1000) >> 16) & 0xFFFF);
       break;
-    }
     case 0x03: // Uptime lower word
-    {
-      unsigned long now = millis() / 1000;
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, (now >> 8) & 0xFF , now & 0xFF);
+      controller->sendDGN(serviceIndex, diagnosticsCode, (millis() / 1000) & 0xFFFF);
       break;
-    }
     case 0x04: // Memory error count -- TODO: not implemented
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, 0, 0);
+      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
       break;
     case 0x05: // Node Number changes
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, highByte(diagNodeNumberChanges), lowByte(diagNodeNumberChanges));
+      controller->sendDGN(serviceIndex, diagnosticsCode, diagNodeNumberChanges);
       break;
     case 0x06: // Received messages acted on 
-    {
-      unsigned int diagMsgsActed = controller->getMessagesActedOn();
-      controller->sendMessageWithNN(OPC_DGN, serviceIndex, diagnosticsCode, highByte(diagMsgsActed), lowByte(diagMsgsActed));
+      controller->sendDGN(serviceIndex, diagnosticsCode, controller->getMessagesActedOn());
       break;
-    }
     default:
       controller->sendGRSP(OPC_RDGN, serviceIndex, GRSP_INVALID_DIAGNOSTIC);
       return;
@@ -128,7 +119,7 @@ void MinimumNodeServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, byt
 
 void MinimumNodeServiceWithDiagnostics::reportAllDiagnostics(byte serviceIndex)
 {
-  controller->sendMessageWithNN(OPC_DGN, serviceIndex, 0, 0, 6);
+  controller->sendDGN(serviceIndex, 0, 6);
   for (byte i = 1; i <= 0x06 ; ++i)
   {
     reportDiagnostics(serviceIndex, i);

--- a/src/MinimumNodeServiceWithDiagnostics.cpp
+++ b/src/MinimumNodeServiceWithDiagnostics.cpp
@@ -88,33 +88,37 @@ void MinimumNodeServiceWithDiagnostics::handleRequestDiagnostics(const VlcbMessa
 
 void MinimumNodeServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, byte diagnosticsCode)
 {
+  unsigned int diagnosticsValue;
   switch (diagnosticsCode)
   {
     case 0x00:
       reportAllDiagnostics(serviceIndex);
-      break;
-    case 0x01: // Status code -- TODO: not implemented, always good
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
-      break;
+      return;
     case 0x02: // Uptime upper word
-      controller->sendDGN(serviceIndex, diagnosticsCode, ((millis() / 1000) >> 16) & 0xFFFF);
+      diagnosticsValue = ((millis() / 1000) >> 16) & 0xFFFF;
       break;
     case 0x03: // Uptime lower word
-      controller->sendDGN(serviceIndex, diagnosticsCode, (millis() / 1000) & 0xFFFF);
-      break;
-    case 0x04: // Memory error count -- TODO: not implemented
-      controller->sendDGN(serviceIndex, diagnosticsCode, 0);
+      diagnosticsValue = (millis() / 1000) & 0xFFFF;
       break;
     case 0x05: // Node Number changes
-      controller->sendDGN(serviceIndex, diagnosticsCode, diagNodeNumberChanges);
+      diagnosticsValue = diagNodeNumberChanges;
       break;
     case 0x06: // Received messages acted on 
-      controller->sendDGN(serviceIndex, diagnosticsCode, controller->getMessagesActedOn());
+      diagnosticsValue = controller->getMessagesActedOn();
       break;
+
+    // Diagnostics codes not yet implemented
+    case 0x01: // Status code -- TODO: not implemented, always good
+    case 0x04: // Memory error count -- TODO: not implemented
+      diagnosticsValue = 0;
+      break;
+
     default:
       controller->sendGRSP(OPC_RDGN, serviceIndex, GRSP_INVALID_DIAGNOSTIC);
       return;
   }
+  
+  controller->sendDGN(serviceIndex, diagnosticsCode, diagnosticsValue);
 }
 
 void MinimumNodeServiceWithDiagnostics::diagNodeNumberChanged()

--- a/src/MinimumNodeServiceWithDiagnostics.cpp
+++ b/src/MinimumNodeServiceWithDiagnostics.cpp
@@ -117,6 +117,11 @@ void MinimumNodeServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, byt
   }
 }
 
+void MinimumNodeServiceWithDiagnostics::diagNodeNumberChanged()
+{
+  ++diagNodeNumberChanges;
+}
+
 void MinimumNodeServiceWithDiagnostics::reportAllDiagnostics(byte serviceIndex)
 {
   controller->sendDGN(serviceIndex, 0, 6);

--- a/src/MinimumNodeServiceWithDiagnostics.h
+++ b/src/MinimumNodeServiceWithDiagnostics.h
@@ -21,9 +21,12 @@ public:
 
 protected:
   virtual void handleMessage(const VlcbMessage *msg) override; 
+  virtual void diagNodeNumberChanged() override;
 
 private:
   void handleRequestDiagnostics(const VlcbMessage *msg, unsigned int nn);
+
+  unsigned int diagNodeNumberChanges = 0;
 };
 
 }

--- a/src/Service.cpp
+++ b/src/Service.cpp
@@ -23,7 +23,7 @@ void Service::reportDiagnostics(byte serviceIndex, byte diagnosticsCode)
 void Service::reportAllDiagnostics(byte serviceIndex)
 {
   // Default implementation is to not support diagnostics.
-  controller->sendMessageWithNN(OPC_DGN, serviceIndex, 0, 0, 0);
+  controller->sendDGN(serviceIndex, 0, 0);
 }
 
 }


### PR DESCRIPTION
Some improvements to improve maintainability and reduce executable size.

There are three changes:

1. Provide a helper function sendDGN() to help with diagnostic value being split in two bytes.
2. Move MNS diagNodeNumberChanges to the MNS diagnostics class to reduce size of non-diagnostic class.
3. Reduce number of calls to sendDGN() in diagnostics classes.
If you want to see these changes one by one click on "commits" and see the differences in each commit.

These changes reduce program size by 12 bytes when not using Diagnostics and 310 bytes when Diagnostics are used.