### PR TITLE
Opc mode handling

### DIFF
--- a/src/EventConsumerService.cpp
+++ b/src/EventConsumerService.cpp
@@ -118,27 +118,31 @@ void EventConsumerService::handleConsumedMessage(const VlcbMessage *msg)
       break;
       
     case OPC_MODE:
-    // 76 - Set Operating Mode
-    //DEBUG_SERIAL << F("ets> MODE -- request op-code received for NN = ") << nn << endl;
-    if (!isThisNodeNumber(nn))
+      // 76 - Set Operating Mode
+      //DEBUG_SERIAL << F("ets> MODE -- request op-code received for NN = ") << nn << endl;
+      if (!isThisNodeNumber(nn))
         {
           // Not for this module.
           return;
-        }
-    controller->messageActedOn();
+        }      
 
-    switch (msg->data[3])
-    {
-      case MODE_EVENT_ACK_ON:
-        // Turn on Event Acknowledge Mode
-        controller->getModuleConfig()->setEventAck(true);
-        break;
+      switch (msg->data[3])
+      {
+        case MODE_EVENT_ACK_ON:
+          // Turn on Event Acknowledge Mode
+          controller->getModuleConfig()->setEventAck(true);
+          break;
 
-      case MODE_EVENT_ACK_OFF:
-        // Turn off Event Acknowledge Mode
-        controller->getModuleConfig()->setEventAck(false);
-        break;
-    }
+        case MODE_EVENT_ACK_OFF:
+          // Turn off Event Acknowledge Mode
+          controller->getModuleConfig()->setEventAck(false);
+          break;
+          
+        default:
+          return;
+      }
+      controller->messageActedOn();
+      break;
 
     default:
       // unknown or unhandled OPC

--- a/src/EventConsumerService.cpp
+++ b/src/EventConsumerService.cpp
@@ -120,7 +120,11 @@ void EventConsumerService::handleConsumedMessage(const VlcbMessage *msg)
     case OPC_MODE:
     // 76 - Set Operating Mode
     //DEBUG_SERIAL << F("ets> MODE -- request op-code received for NN = ") << nn << endl;
-
+    if (!isThisNodeNumber(nn))
+        {
+          // Not for this module.
+          return;
+        }
     controller->messageActedOn();
 
     switch (msg->data[3])

--- a/src/EventTeachingService.cpp
+++ b/src/EventTeachingService.cpp
@@ -111,14 +111,13 @@ void EventTeachingService::handleMessage(const VlcbMessage *msg)
   }
 }
 
-void EventTeachingService::handleLearnMode(const VlcbMessage *msg)
+void EventTeachingService::handleLearnMode(const VlcbMessage *msg, unsigned int nn)
 {
   //DEBUG_SERIAL << F("ets> MODE -- request op-code received for NN = ") << nn << endl;
   if (!isThisNodeNumber(nn))
   {
     return;
   }
-  controller->messageActedOn();
 
   byte requestedMode = msg->data[3];
   switch (requestedMode)
@@ -132,7 +131,11 @@ void EventTeachingService::handleLearnMode(const VlcbMessage *msg)
       // Turn off Learn Mode
       inhibitLearn();
       break;
+      
+    default:
+      return;
   }
+  controller->messageActedOn();
 }
 
 void EventTeachingService::handleLearn(unsigned int nn)

--- a/src/EventTeachingService.cpp
+++ b/src/EventTeachingService.cpp
@@ -45,7 +45,7 @@ void EventTeachingService::handleMessage(const VlcbMessage *msg)
   {
   case OPC_MODE:
     // 76 - Set Operating Mode
-    handleLearnMode(msg);
+    handleLearnMode(msg, nn);
     break;
 
   case OPC_NNLRN:
@@ -114,7 +114,10 @@ void EventTeachingService::handleMessage(const VlcbMessage *msg)
 void EventTeachingService::handleLearnMode(const VlcbMessage *msg)
 {
   //DEBUG_SERIAL << F("ets> MODE -- request op-code received for NN = ") << nn << endl;
-
+  if (!isThisNodeNumber(nn))
+  {
+    return;
+  }
   controller->messageActedOn();
 
   byte requestedMode = msg->data[3];

--- a/src/EventTeachingService.h
+++ b/src/EventTeachingService.h
@@ -28,7 +28,7 @@ private:
   bool bLearn = false;
 
   void handleMessage(const VlcbMessage *msg);
-  void handleLearnMode(const VlcbMessage *msg);
+  void handleLearnMode(const VlcbMessage *msg, unsigned int nn);
   void handleLearn(unsigned int nn);
   void handleUnlearnEvent(const VlcbMessage *msg, unsigned int nn, unsigned int en);
   void handleUnlearn(unsigned int nn);

--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -505,7 +505,7 @@ void MinimumNodeService::handleModeMessage(const VlcbMessage *msg, unsigned int 
       { 
         controller->sendGRSP(OPC_MODE, getServiceID(), CMDERR_INV_CMD);
       }
-      break;
+      return;
   }
   controller->messageActedOn();
 }


### PR DESCRIPTION
Ensure OPC_MODE is only acted upon if it is for this node.
Only send controller->messageActedOn() from the service that acts upon OPC_MODE