### PR TITLE
Initialise MinimumNodeService::notFcuCompatible correctly.

### DIFF
--- a/src/MinimumNodeService.cpp
+++ b/src/MinimumNodeService.cpp
@@ -18,6 +18,8 @@ void MinimumNodeService::begin()
   noHeartbeat = !controller->getModuleConfig()->heartbeat;
   controller->indicateMode(instantMode);
   //DEBUG_SERIAL << F("> instant MODE initialise as: ") << instantMode << endl;
+  
+  notFcuCompatible = !controller->getModuleConfig()->fcuCompatible;
 }
 
 //

--- a/test/VlcbCommon.cpp
+++ b/test/VlcbCommon.cpp
@@ -23,6 +23,7 @@ VLCB::Configuration * createConfiguration()
   configuration->EE_MAX_EVENTS = 20;
   configuration->EE_PRODUCED_EVENTS = 1;
   configuration->EE_NUM_EVS = 2;
+  configuration->setFcuCompatability(false);
   configuration->begin();
   return configuration;
 }


### PR DESCRIPTION
Noticed this when running unit tests.
MinimumNodeService::notFcuCompatible shall be in sync with Configuration::fcuCompatible at all times. Fix here ensures they are in sync even at startup.