### PR TITLE
Commit changes to EEPROM when resetModule() is called

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -576,6 +576,7 @@ void Configuration::resetModule()
   {
     writeNV(i + 1, 0);
   }
+  commitToEEPROM();
 
   // DEBUG_SERIAL << F("> complete in ") << (millis() - t) << F(", rebooting ... ") << endl;
 


### PR DESCRIPTION
Previously we introduced a change that managed committing changes to EEPROM so as to reduce EEPROM wear.  The writes in the resetModule() function were overlooked.  This is only an issue when the module has EEPROM that is in factory, virgin state.  This change resolves the earlier oversight.