### PR TITLE
Add Bounce2 dependency to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Communication
 url=https://github.com/SvenRosvall/VLCB-Arduino
 architectures=*
 includes=VLCB.h,Controller.h,vlcbdefs.hpp,Parameters.h,CAN2515.h,Configuration.h,Switch.h,LED.h
-depends=Streaming,ACAN2515
+depends=Streaming,ACAN2515,Bounce2


### PR DESCRIPTION
Bounce2 is used by the 4 in 4 out sketch. A note was added but it would be better to include it in the dependency file