### PR TITLE
Clear hash table after manufacturer reset.

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -100,6 +100,7 @@ void Configuration::setModuleNormalMode(unsigned int nodeNumber)
     {
       cleareventEEPROM(j);
     }
+    clearEvHashTable();
   }
   
   setModuleMode(MODE_NORMAL);


### PR DESCRIPTION
After manufacturer reset the events on the node are overwritten. But MMC shows the events still with NN:EN as FFFF:FFFF. This is because the EEPROM is cleared but the event hash table is not updated. The list of events returned by the node is based on the entries in the event hash table. 