### PR TITLE
Make canp in CAN2515 private.

### DIFF
--- a/examples/VLCB_1in1out/VLCB_1in1out.ino
+++ b/examples/VLCB_1in1out/VLCB_1in1out.ino
@@ -137,12 +137,12 @@ void loop()
   //
   /// check CAN message buffers
   //
-  if (can2515.canp->receiveBufferPeakCount() > can2515.canp->receiveBufferSize())
+  if (can2515.receiveBufferPeak() > can2515.receiveBufferSize())
   {
     Serial << F("> receive buffer overflow") << endl;
   }
 
-  if (can2515.canp->transmitBufferPeakCount(0) > can2515.canp->transmitBufferSize(0))
+  if (can2515.transmitBufferPeak() > can2515.transmitBufferSize())
   {
     Serial << F("> transmit buffer overflow") << endl;
   }
@@ -150,7 +150,7 @@ void loop()
   //
   /// check CAN bus state
   //
-  byte s = can2515.canp->errorFlagRegister();
+  byte s = can2515.errorStatus();
   if (s != 0)
   {
     Serial << F("> error flag register is non-zero") << endl;

--- a/examples/VLCB_empty/VLCB_empty.ino
+++ b/examples/VLCB_empty/VLCB_empty.ino
@@ -106,12 +106,12 @@ void loop()
   //
   /// check CAN message buffers
   //
-  if (can2515.canp->receiveBufferPeakCount() > can2515.canp->receiveBufferSize())
+  if (can2515.receiveBufferPeak() > can2515.receiveBufferSize())
   {
     Serial << F("> receive buffer overflow") << endl;
   }
 
-  if (can2515.canp->transmitBufferPeakCount(0) > can2515.canp->transmitBufferSize(0))
+  if (can2515.transmitBufferPeak() > can2515.transmitBufferSize())
   {
     Serial << F("> transmit buffer overflow") << endl;
   }
@@ -119,7 +119,7 @@ void loop()
   //
   /// check CAN bus state
   //
-  byte s = can2515.canp->errorFlagRegister();
+  byte s = can2515.errorStatus();
   if (s != 0)
   {
     // Serial << F("> error flag register is non-zero = ") << s << endl;

--- a/examples/VLCB_long_message_example/VLCB_long_message_example.ino
+++ b/examples/VLCB_long_message_example/VLCB_long_message_example.ino
@@ -130,12 +130,12 @@ void loop()
   //
   /// check CAN message buffers
   //
-  if (can2515.canp->receiveBufferPeakCount() > can2515.canp->receiveBufferSize())
+  if (can2515.receiveBufferPeak() > can2515.receiveBufferSize())
   {
     Serial << F("> receive buffer overflow") << endl;
   }
 
-  if (can2515.canp->transmitBufferPeakCount(0) > can2515.canp->transmitBufferSize(0))
+  if (can2515.transmitBufferPeak() > can2515.transmitBufferSize())
   {
     Serial << F("> transmit buffer overflow") << endl;
   }
@@ -146,7 +146,7 @@ void loop()
 
   byte err;
 
-  if ((err = can2515.canp->errorFlagRegister()) != 0)
+  if ((err = can2515.errorStatus()) != 0)
   {
     Serial << F("> error flag register = ") << err << endl;
   }

--- a/src/CAN2515.h
+++ b/src/CAN2515.h
@@ -72,7 +72,7 @@ public:
   virtual unsigned int errorStatus() override { return canp->errorFlagRegister(); }
 
 private:
-  ACAN2515 *canp;   // pointer to CAN object so user code can access its members
+  ACAN2515 *canp;   // pointer to CAN object
   unsigned int _numMsgsSent, _numMsgsRcvd;
   unsigned long _osc_freq;
   byte _csPin, _intPin;

--- a/src/CAN2515.h
+++ b/src/CAN2515.h
@@ -63,15 +63,16 @@ public:
   virtual unsigned int transmitCounter() override { return _numMsgsSent; }
   virtual unsigned int receiveErrorCounter() override { return canp->receiveErrorCounter(); }
   virtual unsigned int transmitErrorCounter() override { return canp->transmitErrorCounter(); }
+  virtual unsigned int receiveBufferSize() override { return canp->receiveBufferSize(); };
+  virtual unsigned int transmitBufferSize() override { return canp->transmitBufferSize(0); };
   virtual unsigned int receiveBufferUsage() override { return canp->receiveBufferCount(); };
   virtual unsigned int transmitBufferUsage() override { return canp->transmitBufferCount(0); };
   virtual unsigned int receiveBufferPeak() override { return canp->receiveBufferPeakCount(); };
   virtual unsigned int transmitBufferPeak() override { return canp->transmitBufferPeakCount(0); };
   virtual unsigned int errorStatus() override { return canp->errorFlagRegister(); }
 
-  ACAN2515 *canp;   // pointer to CAN object so user code can access its members
-
 private:
+  ACAN2515 *canp;   // pointer to CAN object so user code can access its members
   unsigned int _numMsgsSent, _numMsgsRcvd;
   unsigned long _osc_freq;
   byte _csPin, _intPin;

--- a/src/Transport.h
+++ b/src/Transport.h
@@ -16,6 +16,8 @@ public:
 
   virtual unsigned int receiveCounter() = 0;
   virtual unsigned int transmitCounter() = 0;
+  virtual unsigned int receiveBufferSize() = 0;
+  virtual unsigned int transmitBufferSize() = 0;
   virtual unsigned int receiveErrorCounter() = 0;
   virtual unsigned int transmitErrorCounter() = 0;
   virtual unsigned int receiveBufferUsage() = 0;


### PR DESCRIPTION
Made this small change so that "canp" can be private in the class CAN2515 and thus invisible to the outside world.
Noticed that this was included in Doxygen generated files which it shouldn't. 
This is a general change so making this change on a separate branch. Will merge to the UseDoxygen branch later.