### PR TITLE
Action queue stats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ add_library(core_library OBJECT
         src/Storage.h
         src/Service.h
         src/Service.cpp
+        src/InternalDiagnosticsService.cpp
+        src/InternalDiagnosticsService.h
         src/LongMessageService.h
         src/MinimumNodeService.cpp
         src/MinimumNodeService.h

--- a/src/CircularBuffer.h
+++ b/src/CircularBuffer.h
@@ -24,13 +24,13 @@ public:
   void clear();
 
   // Diagnostic metrics access
+  uint8_t bufUse() const;
   unsigned int getNumberOfPuts() const;
   unsigned int getNumberOfGets() const;
   unsigned int getOverflows() const;
   unsigned int getHighWaterMark() const;   // High Water Mark
 
 private:
-  uint8_t bufUse() const;
 
   uint8_t capacity;
   uint8_t head = 0;

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -104,6 +104,8 @@ public:
 
   void messageActedOn();
   unsigned int getMessagesActedOn() { return diagMsgsActed; }
+  
+  const CircularBuffer<Action> & getActionQueue() const { return actionQueue; }
 
 private:
   Configuration *module_config;

--- a/src/InternalDiagnosticsService.cpp
+++ b/src/InternalDiagnosticsService.cpp
@@ -1,0 +1,53 @@
+//  Copyright (C) Sven Rosvall (sven@rosvall.ie)
+//  This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+//  Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+//  The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0
+//
+//
+
+#include "InternalDiagnosticsService.h"
+#include "Controller.h"
+
+namespace VLCB
+{
+
+void InternalDiagnosticsService::reportDiagnostics(byte serviceIndex, byte diagnosticsCode)
+{
+  unsigned int diagnosticsValue;
+  switch (diagnosticsCode)
+  {
+    case 0x00:
+      reportAllDiagnostics(serviceIndex);
+      return;
+    case 0x01: // Free memory.
+      diagnosticsValue = controller->getModuleConfig()->freeSRAM();
+      break;
+    case 0x02: // Action queue: current size
+      diagnosticsValue = controller->getActionQueue().bufUse();
+      break;
+    case 0x03: // Action queue: high water mark
+      diagnosticsValue = controller->getActionQueue().getHighWaterMark();
+      break;
+    case 0x04: // Action queue: number of overflows
+      diagnosticsValue = controller->getActionQueue().getOverflows();
+      break;
+
+    default:
+      controller->sendGRSP(OPC_RDGN, serviceIndex, GRSP_INVALID_DIAGNOSTIC);
+      return;
+  }
+  
+  controller->sendDGN(serviceIndex, diagnosticsCode, diagnosticsValue);
+}
+
+void InternalDiagnosticsService::reportAllDiagnostics(byte serviceIndex)
+{
+  byte diagCount = 4;
+  controller->sendDGN(serviceIndex, 0, diagCount);
+  for (byte i = 1; i <= diagCount ; ++i)
+  {
+    reportDiagnostics(serviceIndex, i);
+  }
+}
+
+}

--- a/src/InternalDiagnosticsService.h
+++ b/src/InternalDiagnosticsService.h
@@ -1,0 +1,39 @@
+//  Copyright (C) Sven Rosvall (sven@rosvall.ie)
+//  This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+//  Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+//  The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0
+//
+//
+
+
+#pragma once
+
+#include "Service.h"
+
+namespace VLCB
+{
+
+/// @brief A dummy service that reports internal metrics as service diagnostics.
+/// 
+/// Use this service to share internal metrics as diagnostics that can be viewed in
+/// configuration utilities.
+/// Supported diagnostics are:
+/// 1) Available memory
+/// 2) ActionQueue current size
+/// 3) ActionQueue high water mark
+/// 4) ActionQueue number of overflows
+class InternalDiagnosticsService : public Service
+{
+public:
+  VlcbServiceTypes getServiceID() const override { return static_cast<VlcbServiceTypes>(240); }
+
+  byte getServiceVersionID() const override { return 1; }
+
+  void process(const Action *action) override {}
+
+  void reportDiagnostics(byte serviceIndex, byte diagnosticsCode) override;
+
+  void reportAllDiagnostics(byte serviceIndex) override;
+};
+
+}

--- a/src/SerialUserInterface.cpp
+++ b/src/SerialUserInterface.cpp
@@ -120,7 +120,14 @@ void SerialUserInterface::processSerialInput()
 
       case 'm':
         // free memory
-        Serial << F("> free SRAM = ") << modconfig->freeSRAM() << F(" bytes") << endl;
+        Serial << F("Free SRAM = ") << modconfig->freeSRAM() << F(" bytes") << endl;
+        break;
+        
+      case 'a':
+        // Action queue info
+        Serial << F("Action Queue Size=") << controller->getActionQueue().bufUse()
+               << F(" High Water Mark=") << controller->getActionQueue().getHighWaterMark() 
+               << F(" Overflows=") << controller->getActionQueue().getOverflows() << endl;
         break;
 
       case 's': // "s" == "setup"


### PR DESCRIPTION
This adds an InternalDiagnosticsService that provides diagnostics for free memory and action queue stats. This means a user sketch does not need the SerialUserInterface for these stats.

But if you want to use the SerialUserInterface the action queue stats are added here too.