### PR TITLE
Remove unused code for Diagnostic 0.

### DIFF
--- a/src/CanServiceWithDiagnostics.cpp
+++ b/src/CanServiceWithDiagnostics.cpp
@@ -15,9 +15,6 @@ void CanServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, byte diagno
   unsigned int diagnosticsValue;
   switch (diagnosticsCode)
   {
-    case 0x00:
-      reportAllDiagnostics(serviceIndex);
-      return;
     case 0x01: // CAN RX error counter
       diagnosticsValue = canTransport->receiveErrorCounter();
       break;

--- a/src/EventConsumerServiceWithDiagnostics.cpp
+++ b/src/EventConsumerServiceWithDiagnostics.cpp
@@ -12,9 +12,6 @@ void EventConsumerServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, b
 {
   switch (diagnosticsCode)
   {
-    case 0x00:
-      reportAllDiagnostics(serviceIndex);
-      break;
     case 0x01: 
       controller->sendDGN(serviceIndex, diagnosticsCode, diagEventsConsumed);
       break;

--- a/src/EventProducerServiceWithDiagnostics.cpp
+++ b/src/EventProducerServiceWithDiagnostics.cpp
@@ -12,9 +12,6 @@ void EventProducerServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, b
 {
   switch (diagnosticsCode)
   {
-    case 0x00:
-      reportAllDiagnostics(serviceIndex);
-      break;
     case 0x01: 
       controller->sendDGN(serviceIndex, diagnosticsCode, diagEventsProduced);
       break;

--- a/src/EventTeachingServiceWithDiagnostics.cpp
+++ b/src/EventTeachingServiceWithDiagnostics.cpp
@@ -12,9 +12,6 @@ void EventTeachingServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, b
 {
   switch (diagnosticsCode)
   {
-    case 0x00:
-      reportAllDiagnostics(serviceIndex);
-      break;
     case 0x01: 
       controller->sendDGN(serviceIndex, diagnosticsCode, diagEventsTaught);
       break;

--- a/src/InternalDiagnosticsService.cpp
+++ b/src/InternalDiagnosticsService.cpp
@@ -16,9 +16,6 @@ void InternalDiagnosticsService::reportDiagnostics(byte serviceIndex, byte diagn
   unsigned int diagnosticsValue;
   switch (diagnosticsCode)
   {
-    case 0x00:
-      reportAllDiagnostics(serviceIndex);
-      return;
     case 0x01: // Free memory.
       diagnosticsValue = controller->getModuleConfig()->freeSRAM();
       break;

--- a/src/MinimumNodeServiceWithDiagnostics.cpp
+++ b/src/MinimumNodeServiceWithDiagnostics.cpp
@@ -91,9 +91,6 @@ void MinimumNodeServiceWithDiagnostics::reportDiagnostics(byte serviceIndex, byt
   unsigned int diagnosticsValue;
   switch (diagnosticsCode)
   {
-    case 0x00:
-      reportAllDiagnostics(serviceIndex);
-      return;
     case 0x02: // Uptime upper word
       diagnosticsValue = ((millis() / 1000) >> 16) & 0xFFFF;
       break;


### PR DESCRIPTION
The reportDiagnostic() function will never be called with diagnosticCode set to zero. MNS will handle this case separately and call reportAllDiagnostics() instead.

Discovered this while working on TimedResponse. Making a separate pull request for this so that it is easier to review the changes for TimedResponse later.