### PR TITLE
CircularBuffer size is a template param instead of dynamic memory.

### DIFF
--- a/src/CircularBuffer.h
+++ b/src/CircularBuffer.h
@@ -10,11 +10,11 @@
 namespace VLCB
 {
 
-template <typename E>
+template <typename E, int bufferCapacity = 4>
 class CircularBuffer
 {
 public:
-  explicit CircularBuffer(uint8_t bufferCapacity = 4);
+  explicit CircularBuffer();
   ~CircularBuffer();
 
   bool available() const;
@@ -25,10 +25,10 @@ public:
 
   // Diagnostic metrics access
   uint8_t bufUse() const;
-  unsigned int getNumberOfPuts() const;
-  unsigned int getNumberOfGets() const;
-  unsigned int getOverflows() const;
-  unsigned int getHighWaterMark() const;   // High Water Mark
+  unsigned int getNumberOfPuts() const { return numPuts; }
+  unsigned int getNumberOfGets() const { return numGets; }
+  unsigned int getOverflows() const { return numOverflows; }
+  unsigned int getHighWaterMark() const { return hwm; }
 
 private:
 
@@ -43,33 +43,31 @@ private:
   uint8_t numGets = 0;
   uint8_t numOverflows = 0;
 
-  E *buffer;
+  E buffer[bufferCapacity];
 };
 
 
-template <typename E>
-CircularBuffer<E>::CircularBuffer(uint8_t bufferCapacity)
+template <typename E, int bufferCapacity>
+CircularBuffer<E, bufferCapacity>::CircularBuffer()
         : capacity(bufferCapacity)
-        , buffer(new E[capacity])
 {}
 
-template <typename E>
-CircularBuffer<E>::~CircularBuffer()
+template <typename E, int bufferCapacity>
+CircularBuffer<E, bufferCapacity>::~CircularBuffer()
 {
-  delete[] buffer;
 }
 
 /// if buffer has one or more stored items
-template <typename E>
-bool CircularBuffer<E>::available() const
+template <typename E, int bufferCapacity>
+bool CircularBuffer<E, bufferCapacity>::available() const
 {
   return full || (head != tail);
 }
 
 /// store an item to the buffer - overwrite the oldest item if buffer is full
 /// never called from an interrupt context so we don't need to worry about interrupts
-template <typename E>
-void CircularBuffer<E>::put(const E &entry)
+template <typename E, int bufferCapacity>
+void CircularBuffer<E, bufferCapacity>::put(const E &entry)
 {
   buffer[head] = entry;
 
@@ -93,8 +91,8 @@ void CircularBuffer<E>::put(const E &entry)
 }
 
 /// retrieve the next item from the buffer, requires that available() is checked first.
-template <typename E>
-const E & CircularBuffer<E>::pop()
+template <typename E, int bufferCapacity>
+const E & CircularBuffer<E, bufferCapacity>::pop()
 {
   uint8_t oldTail = tail;
   full = false;
@@ -105,8 +103,8 @@ const E & CircularBuffer<E>::pop()
 }
 
 /// peek at the next item in the buffer without removing it
-template <typename E>
-E *CircularBuffer<E>::peek()
+template <typename E, int bufferCapacity>
+E *CircularBuffer<E, bufferCapacity>::peek()
 {
   // should always call ::available first to avoid this
   if (available())
@@ -120,8 +118,8 @@ E *CircularBuffer<E>::peek()
 }
 
 /// clear all items
-template <typename E>
-void CircularBuffer<E>::clear()
+template <typename E, int bufferCapacity>
+void CircularBuffer<E, bufferCapacity>::clear()
 {
   head = 0;
   tail = 0;
@@ -129,8 +127,8 @@ void CircularBuffer<E>::clear()
 }
 
 /// recalculate number of items in the buffer
-template <typename E>
-uint8_t CircularBuffer<E>::bufUse() const
+template <typename E, int bufferCapacity>
+uint8_t CircularBuffer<E, bufferCapacity>::bufUse() const
 {
   int8_t size = capacity;
   if (!full)
@@ -142,33 +140,6 @@ uint8_t CircularBuffer<E>::bufUse() const
     }
   }
   return size;
-}
-
-/// number of puts
-template <typename E>
-unsigned int CircularBuffer<E>::getNumberOfPuts() const
-{
-  return numPuts;
-}
-
-/// number of gets
-template <typename E>
-unsigned int CircularBuffer<E>::getNumberOfGets() const
-{
-  return numGets;
-}
-
-/// number of overflows
-template <typename E>
-unsigned int CircularBuffer<E>::getOverflows() const
-{
-  return numOverflows;
-}
-
-template <typename E>
-unsigned int CircularBuffer<E>::getHighWaterMark() const
-{
-  return hwm;
 }
 
 }

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -19,15 +19,6 @@
 namespace VLCB
 {
 
-// TODO: This is a sign something is wrong. Need to be this big to handle 
-// large number of generated messages such as when asking for node parameters.
-// Each entry uses 10 bytes so a size of 30 uses 300 bytes.
-// This will get worse for for example queries for all events.
-// Need a mechanism like TimedResponse to create messages slowly so they can
-// be sent through the transport without requiring this buffering. 
-const int ACTION_QUEUE_SIZE = 30;
-
-
 //Controller::Controller()
 //  : services()
 //  , actionQueue(ACTION_QUEUE_SIZE)
@@ -38,8 +29,6 @@ const int ACTION_QUEUE_SIZE = 30;
 
 Controller::Controller(Configuration *conf)
   : module_config(conf)
-  , services()
-  , actionQueue(ACTION_QUEUE_SIZE)
 {
 }
 
@@ -63,7 +52,6 @@ Controller::Controller(Configuration *conf)
 Controller::Controller(Configuration *conf, std::initializer_list<Service *> services)
   : module_config(conf)
   , services(services)
-  , actionQueue(ACTION_QUEUE_SIZE)
 {
   for (Service * service : services)
   {

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -19,6 +19,15 @@
 
 namespace VLCB
 {
+
+// TODO: This is a sign something is wrong. Need to be this big to handle 
+// large number of generated messages such as when asking for node parameters.
+// Each entry uses 10 bytes so a size of 30 uses 300 bytes.
+// This will get worse for for example queries for all events.
+// Need a mechanism like TimedResponse to create messages slowly so they can
+// be sent through the transport without requiring this buffering. 
+const int ACTION_QUEUE_SIZE = 30;
+
 //
 /// CAN/Controller message type
 //
@@ -106,13 +115,13 @@ public:
   void messageActedOn();
   unsigned int getMessagesActedOn() { return diagMsgsActed; }
   
-  const CircularBuffer<Action> & getActionQueue() const { return actionQueue; }
+  const CircularBuffer<Action, ACTION_QUEUE_SIZE> & getActionQueue() const { return actionQueue; }
 
 private:
   Configuration *module_config;
   ArrayHolder<Service *> services;
 
-  CircularBuffer<Action> actionQueue;
+  CircularBuffer<Action, ACTION_QUEUE_SIZE> actionQueue;
 
   bool sendMessageWithNNandData(VlcbOpCodes opc) { return sendMessageWithNNandData(opc, 0, 0); }
   bool sendMessageWithNNandData(VlcbOpCodes opc, int len, ...);

--- a/test/testCircularBuffer.cpp
+++ b/test/testCircularBuffer.cpp
@@ -26,7 +26,7 @@ void testHasOne()
 {
   test();
   
-  VLCB::CircularBuffer<int> buffer(4);
+  VLCB::CircularBuffer<int, 4> buffer;
   int entry = 17;
   buffer.put(entry);
 
@@ -45,7 +45,7 @@ void testFull()
 {
   test();
   
-  VLCB::CircularBuffer<int> buffer(4);
+  VLCB::CircularBuffer<int, 4> buffer;
   int entry = 1;
   buffer.put(entry);
   buffer.put(entry);
@@ -63,7 +63,7 @@ void testOverflow()
 {
   test();
   
-  VLCB::CircularBuffer<int> buffer(4);
+  VLCB::CircularBuffer<int, 4> buffer;
   int entry = 1;
   buffer.put(entry);
   entry = 2;
@@ -89,7 +89,7 @@ void testHeadWrapAround()
 {
   test();
   
-  VLCB::CircularBuffer<int> buffer(4);
+  VLCB::CircularBuffer<int, 4> buffer;
   int entry = 1;
   buffer.put(entry);
   entry = 2;


### PR DESCRIPTION
This change sets the buffer size at compile time, instead of when the buffer is constructed at run time. This means that the memory used for the buffer is reported at compile time. 

In the old code the memory was allocated at runtime when the object was created. This had the risk that memory could run out at runtime and cause the program to crash.

The memory use reported by freeSRAM() is very similar in both versions so there is no big change. Actually saving 8 bytes of memory which I believe come from the management of dynamic memory.

I hope you don't mind the syntax change where the buffer size is provided when the buffer is defined and being part of the type.