### PR TITLE
Add CI workflows

### DIFF
--- a/.github/workflows/ci-arduino-build.yml
+++ b/.github/workflows/ci-arduino-build.yml
@@ -1,5 +1,8 @@
 name: Arduino Firmware Build
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  
 on:
   pull_request:
     paths:

--- a/.github/workflows/ci-arduino-build.yml
+++ b/.github/workflows/ci-arduino-build.yml
@@ -36,9 +36,11 @@ jobs:
           arduino-cli lib install ACAN2515
           arduino-cli lib install Streaming
 
-      - name: Compile representative examples for Arduino Uno
+      - name: Compile all examples for Arduino Uno
         run: |
-          arduino-cli compile --fqbn arduino:avr:uno --library . ./examples/VLCB_empty
-          arduino-cli compile --fqbn arduino:avr:uno --library . ./examples/VLCB_1in1out
-          arduino-cli compile --fqbn arduino:avr:uno --library . ./examples/VLCB_4in4out
-          arduino-cli compile --fqbn arduino:avr:uno --library . ./examples/VLCB_SerialGC_empty
+          for dir in ./examples/*; do
+            if [ -d "$dir" ] && ls "$dir"/*.ino >/dev/null 2>&1; then
+              echo "Compiling $dir"
+              arduino-cli compile --fqbn arduino:avr:uno --library . "$dir"
+            fi
+          done

--- a/.github/workflows/ci-arduino-build.yml
+++ b/.github/workflows/ci-arduino-build.yml
@@ -1,0 +1,44 @@
+name: Arduino Firmware Build
+
+on:
+  pull_request:
+    paths:
+      - examples/**
+      - src/**
+      - library.properties
+      - .github/workflows/ci-arduino-build.yml
+  push:
+    paths:
+      - examples/**
+      - src/**
+      - library.properties
+      - .github/workflows/ci-arduino-build.yml
+  workflow_dispatch:
+
+jobs:
+  compile-examples:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Arduino CLI
+        uses: arduino/setup-arduino-cli@v2
+
+      - name: Install Arduino core
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install arduino:avr
+
+      - name: Install library dependencies
+        run: |
+          arduino-cli lib install ACAN2515
+          arduino-cli lib install Streaming
+
+      - name: Compile representative examples for Arduino Uno
+        run: |
+          arduino-cli compile --fqbn arduino:avr:uno --library . ./examples/VLCB_empty
+          arduino-cli compile --fqbn arduino:avr:uno --library . ./examples/VLCB_1in1out
+          arduino-cli compile --fqbn arduino:avr:uno --library . ./examples/VLCB_4in4out
+          arduino-cli compile --fqbn arduino:avr:uno --library . ./examples/VLCB_SerialGC_empty

--- a/.github/workflows/ci-host-tests.yml
+++ b/.github/workflows/ci-host-tests.yml
@@ -1,5 +1,8 @@
 name: Host Tests
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  
 on:
   pull_request:
   push:

--- a/.github/workflows/ci-host-tests.yml
+++ b/.github/workflows/ci-host-tests.yml
@@ -1,0 +1,23 @@
+name: Host Tests
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -S . -B build
+
+      - name: Build test target
+        run: cmake --build build --target testAll --config Release
+
+      - name: Run tests
+        run: ./build/testAll

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Docs
+
+on:
+  pull_request:
+    paths:
+      - docs/**
+      - src/**
+      - Doxygen.*.conf
+      - .github/workflows/docs.yml
+  push:
+    paths:
+      - docs/**
+      - src/**
+      - Doxygen.*.conf
+      - .github/workflows/docs.yml
+  workflow_dispatch:
+
+jobs:
+  generate-doxygen:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install documentation tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Generate API documentation
+        run: |
+          doxygen Doxygen.Sketch.conf
+          doxygen Doxygen.Library.conf
+
+      - name: Upload sketch docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-sketch
+          path: html.sketch
+
+      - name: Upload library docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-library
+          path: html.library

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,8 @@
 name: Docs
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  
 on:
   pull_request:
     paths:


### PR DESCRIPTION
### Summary
This PR introduces a split CI structure.

It includes:
- Host CI for CMake build and test execution
- Arduino CI for compiling all example sketches with arduino-cli
- Docs CI for generating Sketch and Library Doxygen output and uploading artifacts

### Why
The goal is to separate responsibilities clearly:
- Host logic verification via CMake tests
- Firmware build verification via arduino-cli
- Documentation generation via Doxygen

Compared to manual runs in developers' environments, this adds:
- Repeatable checks on a clean runner
- Earlier regression detection
- Shared visibility of results
- Less manual verification during review

> Note: This is an addition to the current manual workflows in developers' environments, providing automated CI checks alongside existing local validation.

### Changes

#### CI and docs
- Added host test workflow
- Added Arduino build workflow
- Added docs workflow with Doxygen generation and artifact upload

### Validation
Verified on fork Actions:
- Host CMake workflow passes and executes testAll successfully
- Arduino workflow compiles all examples successfully
- Docs workflow generates and uploads both documentation artifacts successfully

### Related PR
SerialGC follow-up has been split into a separate PR:
- https://github.com/SvenRosvall/VLCB-Arduino/pull/209
