### PR TITLE
Fix SerialGC transport interface and SerialGC_empty wiring

### DIFF
--- a/examples/VLCB_SerialGC_1in1out/VLCB_SerialGC_1in1out.ino
+++ b/examples/VLCB_SerialGC_1in1out/VLCB_SerialGC_1in1out.ino
@@ -83,6 +83,12 @@ void setupVLCB()
   // set module name
   VLCB::setName(mname);
 
+  // configure and start Serial GridConnect transport
+  if (!serialGC.begin())
+  {
+    Serial << F("> error starting VLCB") << endl;
+  }
+
   // register our VLCB event handler, to receive event messages of learned events
   ecService.setEventHandler(eventhandler);
 

--- a/examples/VLCB_SerialGC_4in4out/VLCB_SerialGC_4in4out.ino
+++ b/examples/VLCB_SerialGC_4in4out/VLCB_SerialGC_4in4out.ino
@@ -132,6 +132,12 @@ void setupVLCB()
   // set module name
   VLCB::setName(mname);
 
+  // configure and start Serial GridConnect transport
+  if (!serialGC.begin())
+  {
+    Serial << F("> error starting VLCB") << endl;
+  }
+
   // register our VLCB event handler, to receive event messages of learned events
   ecService.setEventHandler(eventhandler);
   // register the VLCB request event handler to receive event status requests.

--- a/examples/VLCB_SerialGC_4in4out_slot/VLCB_SerialGC_4in4out_slot.ino
+++ b/examples/VLCB_SerialGC_4in4out_slot/VLCB_SerialGC_4in4out_slot.ino
@@ -135,6 +135,12 @@ void setupVLCB()
   // set module name
   VLCB::setName(mname);
 
+  // configure and start Serial GridConnect transport
+  if (!serialGC.begin())
+  {
+    Serial << F("> error starting VLCB") << endl;
+  }
+
   // register our VLCB event handler, to receive event messages of learned events
   ecService.setEventHandler(eventhandler);
   // register the VLCB request event handler to receive event status requests.

--- a/examples/VLCB_SerialGC_empty/VLCB_SerialGC_empty.ino
+++ b/examples/VLCB_SerialGC_empty/VLCB_SerialGC_empty.ino
@@ -47,7 +47,7 @@ VLCB::SerialGC serialGC;                  // CAN transport object using serial
 // Service objects
 VLCB::LEDUserInterface ledUserInterface(LED_GRN, LED_YLW, SWITCH0);
 VLCB::MinimumNodeServiceWithDiagnostics mnService;
-VLCB::CanServiceWithDiagnostics canService(&can2515);
+VLCB::CanServiceWithDiagnostics canService(&serialGC);
 
 //
 /// setup VLCB - runs once at power on from setup()
@@ -66,11 +66,8 @@ void setupVLCB()
   // set module name
   VLCB::setName(mname);
 
-  // configure and start CAN bus and VLCB message processing
-  can2515.setNumBuffers(2, 1);      // more buffers = more memory used, fewer = less
-  can2515.setOscFreq(16000000UL);   // select the crystal frequency of the CAN module
-  can2515.setPins(10, 2);           // select pins for CAN bus CE and interrupt connections
-  if (!can2515.begin())
+  // configure and start Serial GridConnect transport
+  if (!serialGC.begin())
   {
     Serial << F("> error starting VLCB") << endl;
   }

--- a/src/SerialGC.h
+++ b/src/SerialGC.h
@@ -36,6 +36,8 @@ namespace VLCB
 
     virtual unsigned int receiveCounter() override { return receivedCount; }
     virtual unsigned int transmitCounter() override { return transmitCount; }
+    virtual unsigned int receiveBufferSize() override { return RXBUFFERSIZE; }
+    virtual unsigned int transmitBufferSize() override { return RXBUFFERSIZE; }
     virtual unsigned int receiveErrorCounter() override { return receiveErrorCount; }
     virtual unsigned int transmitErrorCounter() override { return transmitErrorCount; }
     virtual unsigned int receiveBufferUsage() override { return 0; };


### PR DESCRIPTION
### Summary
This PR contains the SerialGC consistency follow-up split out from CI work.

It includes:
- SerialGC example updates

### Why
To keep CI infrastructure changes separate from firmware changes.

### Changes

#### SerialGC follow-up
- Added missing SerialGC transport interface methods in [src/SerialGC.h](src/SerialGC.h)
- Fixed transport wiring in [examples/VLCB_SerialGC_empty/VLCB_SerialGC_empty.ino](examples/VLCB_SerialGC_empty/VLCB_SerialGC_empty.ino)

### Validation
Verified on fork:
- SerialGC examples compile with the corrected transport interface and wiring

### Related PR
CI workflows are handled in a separate PR:
- https://github.com/SvenRosvall/VLCB-Arduino/pull/208
