### PR TITLE
Implement Start-of-Day event in 4in4out example

### DIFF
--- a/docs/SketchDevelopment.md
+++ b/docs/SketchDevelopment.md
@@ -74,6 +74,21 @@ The slot event strategy reqires a larger event table but fewer event variables.
 Total memory consumption for the events table is very similar to classic
 events strategy.
 
+### Start-of-Day Event
+A Start-of-Day event is optional an event that is consumed by the node that triggers
+sending out a number of events to indicate the state of inputs on the node.
+These status events are used to update consumers on the layout that depend
+on the state of these inputs.
+An example for this is a control panel that needs to light up the correct
+indicator lights when powered up.
+
+A Start-of-Day event is an ordinary event that a node may consume and trigger
+the sending of status events.
+It is usually recognised with a special value in one of the event variables.
+
+The example sketch VLCB_4in4out.ino illustrates how a Start-of-Day event
+can be implemented. See its [README](VLCB4in4out_README.md#event-variables) file
+
 ## Choosing a module identifier
 A module identifier consists of a _Manufacturer ID_ and a _Module ID_.
 The combination of these two must be unique.

--- a/docs/VLCB4in4out_README.md
+++ b/docs/VLCB4in4out_README.md
@@ -94,7 +94,10 @@ OP_CODE | HEX | Function
 ### Event Variables
 
 Event Variable 1 (EV1) identifies a consumed only event if its value is zero.
-A non-zero value will identify the source (in this case switch) for a produced
+A value of 255 identifies the event as a request for Start-of-Day reporting,
+i.e. send an event for each input to update control panels etc, of the current
+state.
+A value of 1 to 4 will identify the source (in this case switch) for a produced
 event.
 
 ### Consumed Events

--- a/docs/VLCB4in4out_README.md
+++ b/docs/VLCB4in4out_README.md
@@ -94,7 +94,7 @@ OP_CODE | HEX | Function
 ### Event Variables
 
 Event Variable 1 (EV1) identifies a consumed only event if its value is zero.
-A value of 255 identifies the event as a request for Start-of-Day reporting,
+A value of 255 identifies the event as a request for [Start-of-Day reporting](#start-of-day-event),
 i.e. send an event for each input to update control panels etc, of the current
 state.
 A value of 1 to 4 will identify the source (in this case switch) for a produced
@@ -155,6 +155,19 @@ value of 0xFF if not written to. Event Variable 1 will contain the value of
 the producer trigger or switch. If the Event Variables are populated as shown
 in the table in the Consumed Events Section above, the LEDs will respond
 accordingly to a Produced Event.
+
+### Start-of-Day event
+When a Start-of-Day event is received the node will respond
+with an event for each input (switch) to indicate its state.
+
+Note that ON-only switches and OFF-only switches do not
+generate these state events as the state will always be ON or OFF.
+
+A toggle switch should ideally remember its state when
+powering off the node. 
+Instead, the reported state for a toggle switch will be the
+default state unless it has not changed state since start up 
+of the node.
 
 ## Node Variables
 

--- a/examples/MDF/CAN4IN4OUT-0D52-1b.json
+++ b/examples/MDF/CAN4IN4OUT-0D52-1b.json
@@ -61,7 +61,8 @@
         {"label": "Switch 1", "value": 1},
         {"label": "Switch 2", "value": 2},
         {"label": "Switch 3", "value": 3},
-        {"label": "Switch 4", "value": 4}
+        {"label": "Switch 4", "value": 4},
+        {"label": "Start of Day", "value": 255}
       ]
     },
     {

--- a/examples/VLCB_4in4out/VLCB_4in4out.ino
+++ b/examples/VLCB_4in4out/VLCB_4in4out.ino
@@ -42,6 +42,7 @@
 //
 // Event variables:
 //  EV1 - Produce event for switch N where N is EV1 value in the range 1-4. Must be unique.
+//        A value of 255 means a Start-of-Day event.
 //  EV2-5 - Change LED 1-4: 0) No change 1) Normal 2) Slow blink 3) Fast blink
 
 #define DEBUG 1  // set to 0 for no serial debug
@@ -357,6 +358,30 @@ void processSwitches(void)
 }
 
 //
+/// Do Start-of-Day reporting. I.e. send events for each input with their current state.
+//
+void doStartOfDay()
+{
+  DEBUG_PRINT(F("sk> Starting of Day Start"));
+  for (byte i = 0; i < NUM_LEDS; i++)
+  {
+    byte swNum = i + 1;
+    DEBUG_PRINT(F("sk> Button ") << swNum);
+
+    byte eventIndex = VLCB::findExistingEventByEv(1, swNum);
+    if (!VLCB::isEventIndexValid(eventIndex))
+    {
+      // No event for this switch.
+      continue;
+    }
+
+    // TODO: Should we send events for on/off only switches?
+    epService.sendEventAtIndex(state[i], eventIndex);
+  }
+  DEBUG_PRINT(F("sk> Stopping of Day Start"));
+}
+
+//
 /// called from the VLCB library when a learned event is received
 //
 void eventhandler(byte index, const VLCB::VlcbMessage *msg)
@@ -375,6 +400,12 @@ void eventhandler(byte index, const VLCB::VlcbMessage *msg)
     case OPC_ACON:
     case OPC_ASON:
       DEBUG_PRINT(F("sk> case is opCode ON"));
+      if (VLCB::getEventEVval(index, 1) == 0xFF)
+      {
+        doStartOfDay();
+        return;
+      }
+
       for (byte i = 0; i < NUM_LEDS; i++)
       {
         byte ev = i + 2;

--- a/examples/VLCB_4in4out/VLCB_4in4out.ino
+++ b/examples/VLCB_4in4out/VLCB_4in4out.ino
@@ -363,7 +363,7 @@ void processSwitches(void)
 void doStartOfDay()
 {
   DEBUG_PRINT(F("sk> Starting of Day Start"));
-  for (byte i = 0; i < NUM_LEDS; i++)
+  for (byte i = 0; i < NUM_SWITCHES; i++)
   {
     byte swNum = i + 1;
     DEBUG_PRINT(F("sk> Button ") << swNum);
@@ -375,8 +375,20 @@ void doStartOfDay()
       continue;
     }
 
-    // TODO: Should we send events for on/off only switches?
-    epService.sendEventAtIndex(state[i], eventIndex);
+    // Send events for switch that can change state.
+    byte nv = i + 1;
+    byte nvval = VLCB::readNV(nv);
+    switch (nvval)
+    {
+      case 1: // ON and OFF
+      case 4: // Toggle button
+        epService.sendEventAtIndex(state[i], eventIndex);
+        break;
+        
+      default:
+        // Don't send events for other switch types.
+        break;
+    }
   }
   DEBUG_PRINT(F("sk> Stopping of Day Start"));
 }

--- a/examples/VLCB_SerialGC_4in4out/VLCB_SerialGC_4in4out.ino
+++ b/examples/VLCB_SerialGC_4in4out/VLCB_SerialGC_4in4out.ino
@@ -42,11 +42,12 @@
 
 //////////////////////////////////////////////////////////////////////////
 // 
-// Node variables:
+// There are 4 node variables, one for each switch.
 //  NV1-4 - Behaviour of switch 1-4: 0) None 1) On/Off 2) On only 3) Off only 4) Toggle
 //
 // Event variables:
 //  EV1 - Produce event for switch N where N is EV1 value in the range 1-4. Must be unique.
+//        A value of 255 means a Start-of-Day event.
 //  EV2-5 - Change LED 1-4: 0) No change 1) Normal 2) Slow blink 3) Fast blink
 
 #define DEBUG 1  // set to 0 for no serial debug
@@ -358,6 +359,30 @@ void processSwitches(void)
 }
 
 //
+/// Do Start-of-Day reporting. I.e. send events for each input with their current state.
+//
+void doStartOfDay()
+{
+  DEBUG_PRINT(F("sk> Starting of Day Start"));
+  for (byte i = 0; i < NUM_LEDS; i++)
+  {
+    byte swNum = i + 1;
+    DEBUG_PRINT(F("sk> Button ") << swNum);
+
+    byte eventIndex = VLCB::findExistingEventByEv(1, swNum);
+    if (!VLCB::isEventIndexValid(eventIndex))
+    {
+      // No event for this switch.
+      continue;
+    }
+
+    // TODO: Should we send events for on/off only switches?
+    epService.sendEventAtIndex(state[i], eventIndex);
+  }
+  DEBUG_PRINT(F("sk> Stopping of Day Start"));
+}
+
+//
 /// called from the VLCB library when a learned event is received
 //
 void eventhandler(byte index, const VLCB::VlcbMessage *msg)
@@ -376,6 +401,12 @@ void eventhandler(byte index, const VLCB::VlcbMessage *msg)
     case OPC_ACON:
     case OPC_ASON:
       DEBUG_PRINT(F("sk> case is opCode ON"));
+      if (VLCB::getEventEVval(index, 1) == 0xFF)
+      {
+        doStartOfDay();
+        return;
+      }
+
       for (byte i = 0; i < NUM_LEDS; i++)
       {
         byte ev = i + 2;


### PR DESCRIPTION
This is a naive implementation. See #215.  I want to get this working before I implement it with TimedResponse. Otherwise if something fails I don't know if it is the SoD code or the TimedResponse code that failed.

There is a question in the code if we should send SoD response events for inputs that can only be one of ON or OFF. Current code does, which means those events will always be ON or always OFF, which I doubt the usefulness of.