### PR TITLE
Enhance docs workflow with parallel builds and GitHub Pages deployment

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -9,13 +9,13 @@ on:
       - docs/**
       - src/**
       - Doxygen.*.conf
-      - .github/workflows/docs.yml
+      - .github/workflows/ci-docs.yaml
   push:
     paths:
       - docs/**
       - src/**
       - Doxygen.*.conf
-      - .github/workflows/docs.yml
+      - .github/workflows/ci-docs.yaml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -47,3 +47,39 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.path }}
+
+  deploy-gh-pages:
+    needs: [generate-doxygen]
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download sketch docs
+        uses: actions/download-artifact@v4
+        with:
+          name: html-sketch
+          path: html.sketch
+
+      - name: Download library docs
+        uses: actions/download-artifact@v4
+        with:
+          name: html-library
+          path: html.library
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -2,16 +2,18 @@ name: Docs
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  
+
 on:
   pull_request:
     paths:
+      - README.md
       - docs/**
       - src/**
       - Doxygen.*.conf
       - .github/workflows/ci-docs.yaml
   push:
     paths:
+      - README.md
       - docs/**
       - src/**
       - Doxygen.*.conf
@@ -20,30 +22,28 @@ on:
 
 jobs:
   generate-doxygen:
+    strategy:
+      matrix:
+        include:
+          - config: Doxygen.Sketch.conf
+            artifact: html-sketch
+            path: html.sketch
+            label: sketch (user-facing)
+          - config: Doxygen.Library.conf
+            artifact: html-library
+            path: html.library
+            label: library (internal API)
+
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Install documentation tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y doxygen graphviz
+      - name: Generate ${{ matrix.label }} docs
+        run: docker run --rm -v $PWD:/work -w /work ghcr.io/doxygen/doxygen ${{ matrix.config }}
 
-      - name: Generate API documentation
-        run: |
-          doxygen Doxygen.Sketch.conf
-          doxygen Doxygen.Library.conf
-
-      - name: Upload sketch docs artifact
+      - name: Upload docs artifact
         uses: actions/upload-artifact@v4
         with:
-          name: html-sketch
-          path: html.sketch
-
-      - name: Upload library docs artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: html-library
-          path: html.library
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.path }}

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -37,7 +37,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
 
       - name: Generate ${{ matrix.label }} docs
         run: docker run --rm -v $PWD:/work -w /work ghcr.io/doxygen/doxygen ${{ matrix.config }}
@@ -57,8 +58,9 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
-
+      - name: Check out repository
+        uses: actions/checkout@v4
+        
       - name: Download sketch docs
         uses: actions/download-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 .idea
 build
 
+# CI generates and deploys these automatically
+html.sketch/
+html.library/
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,18 @@
 
 .DS_Store
 .idea
-build
+build/
 
 # CI generates and deploys these automatically
 html.sketch/
 html.library/
+
+# Visual Studio Code
+.vscode/
+build-vscode/
+CMakePresets.json
+
+# Local working notes
+notes/
+
 

--- a/docs/Doxygen.md
+++ b/docs/Doxygen.md
@@ -15,9 +15,22 @@ The VLCB-Arduino library has two sets of API documentation, one complete
 set for library developers, and a second restricted set that describes 
 functions and objects that sketch developers need.
 
-## Using Doxygen in VLCB-Arduino
+## CI-automated documentation
 
-Download and install Doxygen from https://www.doxygen.nl/
+The documentation is generated automatically by a [GitHub Actions workflow](../.github/workflows/ci-docs.yaml)
+on every push or pull request that changes source files or documentation.
+On pushes to the `main` branch, the generated documentation is deployed to GitHub Pages.
+
+The live documentation is available at:
+- [Library developer docs](https://svenrosvall.github.io/VLCB-Arduino/html.library/index.html)
+- [Sketch developer docs](https://svenrosvall.github.io/VLCB-Arduino/html.sketch/index.html)
+
+The main repository is maintained at https://svenrosvall.github.io/VLCB-Arduino
+
+## Generating documentation locally
+
+For previewing changes before pushing, generate the documentation locally.
+Download and install Doxygen from https://www.doxygen.nl/.
 
 Doxygen requires a configuration file.
 This is [Doxygen.conf](../Doxygen.Sketch.conf) in the root directory.
@@ -30,32 +43,13 @@ doxygen Doxygen.Library.conf
 This updates documentation in the `html.sketch` directory and 
 `html.library` directory respectively.
 
-Once the documentation is updated, review it and commit to git.
-Note that some new files may have been created. 
-These needed to be staged for addition to git.
-
-## Browsing the generated documentation
-
 Read the generated documentation locally by opening one of the
 [Sketch developer index file](../html.sketch/index.html) or
 [Library developer index file](../html.library/index.html)
 in your browser.
 
-If you browse the index file from Github you will see the raw HTML
-source code.
-Github has a feature (called "pages") that renders the HTML pages
-(and Markdown pages).
-Enable the "pages" in **Settings** in the Github repository.
-Select **Pages** on the left.
-Set **Source** to "Deploy from a brach" and under **Branch** choose
-the branch that is used for documentation (if anything else than "main").
-The directory shall be "/ (root)".
-Press [Save] and you are done.
-The pages will now be available at https:<your-username>.githop.io/VLCB-Arduino.
-(See https://stackoverflow.com/questions/8446218/how-to-see-an-html-page-on-github-as-a-normal-rendered-html-page-to-see-preview)
-
-The main repository will be maintained in https://svenrosvall.github.io/VLCB-Arduino
-The index of the generated documentation is available at https://svenrosvall.github.io/VLCB-Arduino/html.library/index.html
+> **Note**: Do not commit the generated `html.sketch/` or `html.library/` directories.
+> The CI workflow generates and deploys them automatically.
 
 ## What to document
 High level documentation is kept in the `docs` directory.

--- a/docs/Doxygen.md
+++ b/docs/Doxygen.md
@@ -21,11 +21,11 @@ The documentation is generated automatically by a [GitHub Actions workflow](../.
 on every push or pull request that changes source files or documentation.
 On pushes to the `main` branch, the generated documentation is deployed to GitHub Pages.
 
-The live documentation is available at:
+The generated documentation is available at:
 - [Library developer docs](https://svenrosvall.github.io/VLCB-Arduino/html.library/index.html)
 - [Sketch developer docs](https://svenrosvall.github.io/VLCB-Arduino/html.sketch/index.html)
 
-The main repository is maintained at https://svenrosvall.github.io/VLCB-Arduino
+The main documentation page is available here: https://svenrosvall.github.io/VLCB-Arduino
 
 ## Generating documentation locally
 


### PR DESCRIPTION
This PR upgrades the documentation CI workflow:

- Parallelized Doxygen generation — both configs (Sketch + Library) build concurrently using Docker, replacing sequential `apt-get install`
- Added GitHub Pages deployment — on push to `main`, generated docs are automatically deployed to GitHub Pages
- Updated `docs/Doxygen.md` to reflect CI-automated workflow and removed stale manual instructions

Closes #221 