### PR TITLE
Add missing environment field for deploy-pages

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -53,6 +53,8 @@ jobs:
     needs: [generate-doxygen]
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
In the workflow, `action/deploy-pages@v4` requires the job to declare environment: github-pages, which was missing from the deploy-gh-pages job. The GitHub API rejects the deployment creation without it.