### PR TITLE
Add pass/fail summary to arduino build workflow

### DIFF
--- a/.github/workflows/ci-arduino-build.yml
+++ b/.github/workflows/ci-arduino-build.yml
@@ -41,9 +41,20 @@ jobs:
 
       - name: Compile all examples for Arduino Uno
         run: |
+          results=""
           for dir in ./examples/*; do
             if [ -d "$dir" ] && ls "$dir"/*.ino >/dev/null 2>&1; then
+              exname=$(basename "$dir")
               echo "Compiling $dir"
-              arduino-cli compile --fqbn arduino:avr:uno --library . "$dir"
+              if arduino-cli compile --fqbn arduino:avr:uno --library . "$dir"; then
+                results="$results  PASS  $exname"$'\n'
+              else
+                results="$results  FAIL  $exname"$'\n'
+              fi
             fi
           done
+          echo "=== Summary ==="
+          echo "$results"
+          if echo "$results" | grep -q "^  FAIL"; then
+            exit 1
+          fi

--- a/examples/build_failure_test/build_failure_test.ino
+++ b/examples/build_failure_test/build_failure_test.ino
@@ -1,0 +1,8 @@
+void setup()
+{
+    int error
+}
+
+void loop()
+{
+}

--- a/examples/build_failure_test/build_failure_test.ino
+++ b/examples/build_failure_test/build_failure_test.ino
@@ -1,8 +1,0 @@
-void setup()
-{
-    int error
-}
-
-void loop()
-{
-}


### PR DESCRIPTION
A small change to the workflow to report a build Pass/Fail for each example. The workflow will process all examples and no longer stop on build failure. A final verdict will be given at the end.

```
Compiling ./examples/VLCB_SerialGC_1in1out
Sketch uses 22760 bytes (70%) of program storage space. Maximum is 32256 bytes.
Global variables use 1215 bytes (59%) of dynamic memory, leaving 833 bytes for local variables. Maximum is 2048 bytes.
Compiling ./examples/VLCB_SerialGC_4in4out
Sketch uses 24600 bytes (76%) of program storage space. Maximum is 32256 bytes.
Global variables use 1341 bytes (65%) of dynamic memory, leaving 707 bytes for local variables. Maximum is 2048 bytes.
Compiling ./examples/VLCB_SerialGC_4in4out_slot
Sketch uses 23588 bytes (73%) of program storage space. Maximum is 32256 bytes.
Global variables use 1331 bytes (64%) of dynamic memory, leaving 717 bytes for local variables. Maximum is 2048 bytes.
Compiling ./examples/VLCB_SerialGC_SerialUI_empty
Sketch uses 23794 bytes (73%) of program storage space. Maximum is 32256 bytes.
Global variables use 1149 bytes (56%) of dynamic memory, leaving 899 bytes for local variables. Maximum is 2048 bytes.
Compiling ./examples/VLCB_SerialGC_empty
Sketch uses 18004 bytes (55%) of program storage space. Maximum is 32256 bytes.
Global variables use 986 bytes (48%) of dynamic memory, leaving 1062 bytes for local variables. Maximum is 2048 bytes.
=== Summary ===
  PASS  VLCB_SerialGC_1in1out
  PASS  VLCB_SerialGC_4in4out
  PASS  VLCB_SerialGC_4in4out_slot
  PASS  VLCB_SerialGC_SerialUI_empty
  PASS  VLCB_SerialGC_empty
```