### PR TITLE
Github workflow to compile example sketches on RPi Pico and ESP32.

### DIFF
--- a/.github/workflows/ci-arduino-build.yml
+++ b/.github/workflows/ci-arduino-build.yml
@@ -21,6 +21,22 @@ on:
 
 jobs:
   compile-examples:
+    strategy:
+      fail-fast: false # The default is to abort if one of the jobs fails, so do not abort
+
+      matrix:
+        include:
+          - label: Arduino Uno
+            board: arduino:avr:uno
+            platform: arduino:avr
+          - label: Raspberry Pico
+            board: rp2040:rp2040:rpipico
+            platform: rp2040:rp2040
+            install-args: --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+          - label: Espressif ESP32
+            board: esp32:esp32:esp32c6
+            platform: esp32:esp32
+
     runs-on: ubuntu-latest
 
     steps:
@@ -33,20 +49,20 @@ jobs:
       - name: Install Arduino core
         run: |
           arduino-cli core update-index
-          arduino-cli core install arduino:avr
+          arduino-cli core install ${{ matrix.platform }} ${{ matrix.install-args }}
 
       - name: Install library dependencies
         run: |
           arduino-cli lib install Streaming
 
-      - name: Compile all examples for Arduino Uno
+      - name: Compile all examples for ${{ matrix.label }}
         run: |
           results=""
           for dir in ./examples/*; do
             if [ -d "$dir" ] && ls "$dir"/*.ino >/dev/null 2>&1; then
               exname=$(basename "$dir")
               echo "Compiling $dir"
-              if arduino-cli compile --fqbn arduino:avr:uno --library . "$dir"; then
+              if arduino-cli compile --fqbn ${{ matrix.board }} --library . "$dir"; then
                 results="$results  PASS  $exname"$'\n'
               else
                 results="$results  FAIL  $exname"$'\n'

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -28,7 +28,7 @@ and services.
   will include queues.
 * The core library only provides a concrete CanTransport for CAN over serial communication
   by the SerialGC class. 
-  Other implementations for hardware CAN tranceivers are located in their own
+  Other implementations for hardware CAN controllers are located in their own
   libraries. This way this library does not need to dependend on other hardware
   libraries used by the transport libraries.
 

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -1,11 +1,21 @@
 # Example Sketches
 A few example sketches are included in the `examples` directory.
 These illustrate how this library can be used.
+To test or re-use these example sketches pin assignments and any other
+hardware specific configuration must be adjusted for the board being used.
 
-As this library does not contain any support for hardware CAN tranceivers,
+The example sketches are intended to work with any platform supported by
+Arduino IDE, but there are no guarantees that this will work as we cannot
+test all sketches on all platforms.
+We do regular test compiles of these example sketches for Arduino Uno, 
+Raspberry Pi Pico and ESP32. See [GitHub Workflows](GitHubWorkflowsTutorial.md#2-arduino-firmware-build-workflow).
+
+As this library does not contain any support for hardware CAN controllers,
 all of these examples use the simpler serial CAN transport. 
+Example sketches for specific CAN controllers are provided with the libraries
+that support those controllers.
 
-This setup is useful for testing as it does not require any CAN bus equipment
+This serial CAN setup is useful for testing as it does not require any CAN bus equipment
 such as CANUSB or CANETHER.
 Instead, simply use a USB cable connected between a computer and the Arduino
 (same cable as is used for programming the Arduino).
@@ -16,8 +26,8 @@ You can then start FCU (or any other configuration utility) and connect through
 this serial port.
 The FCU will then communicate with your Arduino module as a CBUS module.
 
-Libraries that implement support for hardware CAN tranceivers contain
-similar example sketches as these but using those CAN tranceivers instead.
+Libraries that implement support for hardware CAN controllers contain
+similar example sketches as these but using those CAN controllers instead.
 
 ## Common structure
 All the example sketches have a structure that defines all the necessary

--- a/examples/VLCB_SerialGC_SerialUI_empty/VLCB_SerialGC_SerialUI_empty.ino
+++ b/examples/VLCB_SerialGC_SerialUI_empty/VLCB_SerialGC_SerialUI_empty.ino
@@ -7,7 +7,7 @@
       3rd party libraries needed for compilation: (not for binary-only distributions)
 
       Streaming      -- C++ stream style output, v5, (http://arduiniana.org/libraries/streaming/)
-      SoftwareSerial -- Arduino software serial library (not needed when USE_MEGA_SERIAL1 is set)
+      SoftwareSerial -- Arduino software serial library (not needed when USE_SERIAL1 is set)
 */
 
 // This example demonstrates split serial usage:
@@ -15,7 +15,7 @@
 // - SerialGC uses the default hardware Serial port for GridConnect transport.
 // - SerialUserInterface uses SoftwareSerial for user commands and status output.
 // - On Mega2560, hardware Serial1 can optionally be used for SerialUserInterface.
-//   This is controlled by the USE_MEGA_SERIAL1 macro, which can be defined
+//   This is controlled by the USE_SERIAL1 macro, which can be defined
 //   either in the sketch (Arduino IDE) or as a build flag (e.g. in platformio.ini).
 //
 // To allow concurrent use of SerialGC and SerialUserInterface, the library lets
@@ -37,12 +37,12 @@
 
 #if defined(ESP32)
 // ESP32 do not provide SoftwareSerial.h, but they have a second serial port so we can use Serial1.
-#define USE_MEGA_SERIAL1
+#define USE_SERIAL1
 #endif
 
 // 3rd party libraries
 #include <Streaming.h>
-#ifndef USE_MEGA_SERIAL1
+#ifndef USE_SERIAL1
 #include <SoftwareSerial.h>
 #endif
 
@@ -68,8 +68,9 @@ const byte LED_GRN = 4;             // VLCB green Unitialised LED pin
 const byte LED_YLW = 7;             // VLCB yellow Normal LED pin
 const byte SWITCH0 = 8;             // VLCB push button switch pin
 
-#ifdef USE_MEGA_SERIAL1
-// Use hardware Serial1 on pins 18 (TX1) and 19 (RX1)
+#ifdef USE_SERIAL1
+// For MEGA, use hardware Serial1 on pins 18 (TX1) and 19 (RX1)
+// For ESP32, the hardware Serial1 pins can be set in Serial1.begin().
 #define serialUserPort Serial1
 #else
 // Use SoftwareSerial on pins 2 (RX) and 3 (TX)
@@ -80,7 +81,7 @@ SoftwareSerial serialUserPort(UI_RX_PIN, UI_TX_PIN);
 
 // module objects
 VLCB::SerialGC serialGC(Serial);                                // CAN transport object using hardware serial
-VLCB::SerialUserInterface serialUserInterface(serialUserPort);  // User interface object using either SoftwareSerial or Serial1, depending on USE_MEGA_SERIAL1
+VLCB::SerialUserInterface serialUserInterface(serialUserPort);  // User interface object using either SoftwareSerial or Serial1, depending on USE_SERIAL1
 
 // Service objects
 VLCB::LEDUserInterface ledUserInterface(LED_GRN, LED_YLW, SWITCH0);
@@ -124,7 +125,7 @@ void setup()
   serialUserPort.begin(9600);
   delay(2000);  // Give some time to PIO to open the serial monitor before printing anything
 
-#ifdef USE_MEGA_SERIAL1
+#ifdef USE_SERIAL1
   serialUserPort << F("> ** VLCB split: SerialGC + Serial1 UI example ** ") << __FILE__ << endl;
 #else
   serialUserPort << F("> ** VLCB split: SerialGC + SoftwareSerial UI example ** ") << __FILE__ << endl;

--- a/examples/VLCB_SerialGC_SerialUI_empty/VLCB_SerialGC_SerialUI_empty.ino
+++ b/examples/VLCB_SerialGC_SerialUI_empty/VLCB_SerialGC_SerialUI_empty.ino
@@ -35,6 +35,11 @@
 //
 // Based on the VLCB_SerialGC_empty example from Sven Rosvall (MERG 3777).
 
+#if defined(ESP32)
+// ESP32 do not provide SoftwareSerial.h, but they have a second serial port so we can use Serial1.
+#define USE_MEGA_SERIAL1
+#endif
+
 // 3rd party libraries
 #include <Streaming.h>
 #ifndef USE_MEGA_SERIAL1


### PR DESCRIPTION
Extend the Arduino Firmware Build workflow to compile the example sketches for AVR, RPi Pico and ESP32 platforms. 